### PR TITLE
Fix anchor links on filters page

### DIFF
--- a/platform/liquid/filters.md
+++ b/platform/liquid/filters.md
@@ -505,7 +505,7 @@ Returns the integer length of the input string.
 ### slice
 
 {% hint style="info" %}
-This filter also works for [arrays](https://learn.mechanic.dev/platform/liquid/filters#slice-1)! And there's a different behavior available for [hashes](https://learn.mechanic.dev/platform/liquid/filters#slice-2).
+This filter also works for [arrays](#slice-1)! And there's a different behavior available for [hashes](#slice-2).
 {% endhint %}
 
 This filter accepts an integer offset, and an optional integer length \(defaulting to 1\). It returns a substring, beginning at the provided index, having the provided length.
@@ -920,7 +920,7 @@ This filter can be used on any array. Used without any arguments, it returns a s
 ### slice
 
 {% hint style="info" %}
-This filter also works for [strings](https://learn.mechanic.dev/platform/liquid/filters#slice)! And there's a different behavior available for [hashes](https://learn.mechanic.dev/platform/liquid/filters#slice-2).
+This filter also works for [strings](#slice)! And there's a different behavior available for [hashes](#slice-2).
 {% endhint %}
 
 This filter accepts an integer offset, and an optional integer length \(defaulting to 1\). If the length is 1, it returns the single element found at that index of the input array. Otherwise, it returns a slice of the array, beginning at the provided index, having the provided length.
@@ -1109,7 +1109,7 @@ Returns an array of keys found in the supplied hash.
 ### slice \*
 
 {% hint style="info" %}
-This filter has alternate behavior for [arrays](https://learn.mechanic.dev/platform/liquid/filters#slice-1) and [strings](https://learn.mechanic.dev/platform/liquid/filters#slice)!
+This filter has alternate behavior for [arrays](#slice-1) and [strings](#slice)!
 {% endhint %}
 
 When applied to a hash, the slice filter accepts one or more string arguments, corresponding to keys that the hash may contain. This filter will then return a new hash, containing only matching key/value pairs from the original hash.

--- a/platform/liquid/filters.md
+++ b/platform/liquid/filters.md
@@ -505,7 +505,7 @@ Returns the integer length of the input string.
 ### slice
 
 {% hint style="info" %}
-This filter also works for [arrays](#slice-1)! And there's a different behavior available for [hashes](#slice-2).
+This filter also works for [arrays](filters.md#slice-1)! And there's a different behavior available for [hashes](filters.md#slice-2).
 {% endhint %}
 
 This filter accepts an integer offset, and an optional integer length \(defaulting to 1\). It returns a substring, beginning at the provided index, having the provided length.
@@ -920,7 +920,7 @@ This filter can be used on any array. Used without any arguments, it returns a s
 ### slice
 
 {% hint style="info" %}
-This filter also works for [strings](#slice)! And there's a different behavior available for [hashes](#slice-2).
+This filter also works for [strings](filters.md#slice)! And there's a different behavior available for [hashes](filters.md#slice-2).
 {% endhint %}
 
 This filter accepts an integer offset, and an optional integer length \(defaulting to 1\). If the length is 1, it returns the single element found at that index of the input array. Otherwise, it returns a slice of the array, beginning at the provided index, having the provided length.
@@ -1109,7 +1109,7 @@ Returns an array of keys found in the supplied hash.
 ### slice \*
 
 {% hint style="info" %}
-This filter has alternate behavior for [arrays](#slice-1) and [strings](#slice)!
+This filter has alternate behavior for [arrays](filters.md#slice-1) and [strings](filters.md#slice)!
 {% endhint %}
 
 When applied to a hash, the slice filter accepts one or more string arguments, corresponding to keys that the hash may contain. This filter will then return a new hash, containing only matching key/value pairs from the original hash.


### PR DESCRIPTION
All of the anchor links were set as full-path urls, which causes gitbook to open up a new page instead of just scrolling the page. This pull request should fix that.

**Verification is needed to make sure that the correct link format was used.** I would have expected the format for an anchor link to be `[text](#anchor)`, but based on other files in the repository it seems to be `[text](filename.md#anchor)`

I ran the following regex search on the repo and wasn't able to find any other instances of this problem:
```regex
(?<![# \\"]|\.md)#[a-zA-Z0-9%\-_]*(?![# ])
```