### PR TITLE
Fixed Except example in liquid filters

### DIFF
--- a/platform/liquid/filters.md
+++ b/platform/liquid/filters.md
@@ -1097,7 +1097,7 @@ This filter accepts one or more string arguments, corresponding to keys that sho
 
 {% tab title="Output" %}
 ```javascript
-{"bar":"bar","baz":"baz"}
+{"qux":"qux"}
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The example code here is wrong, it seems to be doing the opposite.