### PR TITLE
Document __perform_event control parameter

### DIFF
--- a/core/actions/README.md
+++ b/core/actions/README.md
@@ -9,6 +9,8 @@ In Mechanic, actions are performed after their originating task run concludes. A
 
 To inspect and respond to the results of an HTTP action, add a task subscription to mechanic/actions/perform, allowing the action to re-invoke the task with the action result data.
 
+If you don't need the follow-up event for a particular action, add `__perform_event: false` to that action to skip emitting mechanic/actions/perform while still performing the action.
+
 Learn more: [Responding to action results](../../techniques/responding-to-action-results.md)
 {% endhint %}
 

--- a/core/tasks/code/action-objects.md
+++ b/core/tasks/code/action-objects.md
@@ -36,6 +36,22 @@ The action **type** is always a string, having a value that corresponds to [a su
 
 Action **options** vary by action type. Depending on the action type, its options may be another complete object, or an array, or a scalar value.
 
+#### Control parameters
+
+Mechanic reserves a small set of double-underscore parameters for controlling how an action is handled. The current control parameter is `__perform_event`. Set it to `false` to skip emitting the follow-up `mechanic/actions/perform` event for that specific action (the default is to emit it).
+
+Examples:
+
+```liquid
+{%- action "http", method: "get", url: "https://postman-echo.com/get", __perform_event: false -%}
+```
+
+```liquid
+{%- action "shopify", __perform_event: false -%}
+  mutation { shop { id } }
+{%- endaction -%}
+```
+
 ### Meta
 
 Actions may optionally include **meta** information, annotating the action with any JSON value.

--- a/platform/events/topics.md
+++ b/platform/events/topics.md
@@ -17,7 +17,7 @@ Incoming events may be selectively filtered out using [event filters](filters.md
 ### Actions
 
 * **mechanic/actions/perform**\
-  Occurs when an action has been performed, regardless of its success or failure. A task may subscribe to this topic to be notified when each of its actions have been performed, so that the task may then respond to the results.
+  Occurs when an action has been performed, regardless of its success or failure. A task may subscribe to this topic to be notified when each of its actions have been performed, so that the task may then respond to the results. To skip emitting this follow-up for a specific action, set `__perform_event: false` on that action.
 
 ### Emails
 

--- a/platform/liquid/tags/action.md
+++ b/platform/liquid/tags/action.md
@@ -2,6 +2,8 @@
 
 The **action tag** renders an [**action object**](../../../core/tasks/code/action-objects.md) in JSON, which in turn defines work to be performed by an [**action**](../../../core/actions/).
 
+Mechanic also recognizes certain double-underscore control parameters on actions. The most common is `__perform_event: false`, which tells Mechanic _not_ to emit the follow-up `mechanic/actions/perform` event for that action. Control parameters work with every syntax shown below.
+
 ## Syntax
 
 This tag has several usage styles, each style resulting in valid JSON for an action object.
@@ -171,6 +173,32 @@ This usage style accepts two arguments: the action type, and the action options.
     }
   }
 }
+```
+{% endtab %}
+{% endtabs %}
+
+## Control parameters
+
+Control parameters adjust how Mechanic handles the resulting action. Add them inline with a double-underscore key. Today, `__perform_event: false` is available to skip emitting the follow-up `mechanic/actions/perform` event for that action while still running the action itself.
+
+{% tabs %}
+{% tab title="Positional" %}
+```liquid
+{% action "cache", "set", "foo", "bar", __perform_event: false %}
+```
+{% endtab %}
+
+{% tab title="Mapped" %}
+```liquid
+{% action "http", method: "get", url: "https://postman-echo.com/get", __perform_event: false %}
+```
+{% endtab %}
+
+{% tab title="Shopify GraphQL" %}
+```liquid
+{% action "shopify", __perform_event: false %}
+  mutation { shop { id } }
+{% endaction %}
 ```
 {% endtab %}
 {% endtabs %}

--- a/techniques/responding-to-action-results.md
+++ b/techniques/responding-to-action-results.md
@@ -4,6 +4,8 @@ Action runs are performed asynchronously, [like all Mechanic runs](../core/runs/
 
 To respond to action results, add a task subscription to the **mechanic/actions/perform** event topic. When a task includes this subscription, Mechanic will generate an event with that topic for every action that the task completes. This event will only ever be responded to by the task that generated it; it will never be sent to other tasks.
 
+If you don't need the follow-up event for a particular action (for example, when you know the work is fire-and-forget or you're avoiding loops), set `__perform_event: false` on that action. The action still runs; Mechanic just skips emitting `mechanic/actions/perform` for it.
+
 Common use cases:
 
 * Evaluating [HTTP](../core/actions/http.md) response codes or payloads


### PR DESCRIPTION
## Summary
- document the __perform_event control parameter for actions that should skip emitting mechanic/actions/perform
- add inline examples across positional, mapped, and Shopify GraphQL action tag styles
- clarify follow-up event behavior in action overview and action-results technique docs

## Testing
- docs-only