### PR TITLE
Remove Google Sheets FAQ link

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -258,7 +258,6 @@
   * [Can I query external APIs?](faq/can-i-query-external-apis.md)
   * [Why can't I access the Shopify API during preview mode?](faq/why-cant-i-access-the-shopify-api-during-preview-mode.md)
   * [How do marketing preferences work with Mechanic?](faq/how-do-marketing-preferences-work-with-mechanic.md)
-  * [Can I send data to Google Sheets?](faq/can-i-send-data-to-google-sheets.md)
   * [What's possible with timeline comments?](faq/whats-possible-with-timeline-comments.md)
   * [I'm getting a "query param length is too long" error when using GraphQL.](faq/query-param-length-is-too-long.md)
   * [Can my Mechanic concurrency limit be raised?](faq/can-my-mechanic-concurrency-limit-be-raised.md)


### PR DESCRIPTION
## Summary
- remove the SUMMARY.md entry for the Google Sheets FAQ since the page was deleted

## Testing
- docs-only