### PR TITLE
Add Mechanic MCP Server documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+claude.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-claude.md
+/claude.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,255 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About This Repository
+
+This is the documentation repository for Mechanic, a Shopify development and automation platform. The documentation is structured in GitBook format and covers:
+
+- **Core Concepts**: Events, Tasks, Actions, Runs, and Shopify integration
+- **Platform**: Liquid templating, GraphQL, integrations, caching, email
+- **Resources**: Task library, tutorials, video walkthroughs
+- **Techniques**: Best practices for task development
+- **FAQ**: Common questions and troubleshooting
+
+The documentation is published and rendered through GitBook, with markdown files containing GitBook-specific syntax like `{% hint %}`, `{% tabs %}`, and `{% endtabs %}`.
+
+## Commands
+
+### Git Operations
+
+```bash
+git status                          # Check repository status
+git add .                          # Stage all changes
+git commit -m "message"            # Commit with message
+git push                           # Push to remote
+```
+
+### Viewing Documentation
+
+The documentation is served through GitBook. Files are written in markdown with GitBook extensions.
+
+## Architecture Overview
+
+### Content Structure
+
+```text
+├── core/                          # Core concepts documentation
+│   ├── actions/                   # Action types and integrations
+│   ├── events/                    # Event system
+│   ├── runs/                      # Run queue and execution
+│   ├── shopify/                   # Shopify API integration
+│   └── tasks/                     # Task system
+├── platform/                      # Platform features
+│   ├── cache/                     # Caching system
+│   ├── email/                     # Email functionality
+│   ├── graphql/                   # GraphQL documentation
+│   ├── liquid/                    # Liquid templating
+│   └── integrations/              # Third-party integrations
+├── techniques/                    # Development patterns
+├── resources/                     # Task library, tutorials
+├── faq/                          # Frequently asked questions
+├── .gitbook/assets/              # Images and media files
+├── SUMMARY.md                    # GitBook table of contents
+└── README.md                     # Introduction page
+```
+
+### Key Concepts
+
+#### Execution Model
+
+Mechanic follows a hierarchical execution model:
+
+```text
+Trigger → Event → EventRun → TaskRun(s) → ActionRun(s)
+```
+
+* **Events**: Represent anything that happens (Shopify webhooks, schedules, custom events)
+* **Tasks**: Liquid scripts that respond to events via subscriptions
+* **Actions**: Side effects produced by tasks (Shopify API calls, emails, HTTP requests, files)
+* **Runs**: Execution units processed through queues (event runs → task runs → action runs)
+
+#### Liquid Templating
+
+Tasks are written in Liquid with Mechanic-specific extensions:
+
+* Custom tags: `{% action %}`, `{% log %}`, `{% error %}`, `{% permissions %}`
+* Custom filters: `shopify`, `graphql_arguments`, `parse_json`, `csv`, `hmac_sha256`
+* Keyword literals: `hash`, `array`, `newline`
+* Mechanic objects: `event`, `task`, `options`, `cache`, `action`
+
+#### Action System
+
+Actions are defined using JSON or the `{% action %}` tag:
+
+```liquid
+{% action "shopify" %}
+  mutation {
+    customerCreate(input: { email: "test@example.com" }) {
+      customer { id }
+      userErrors { field message }
+    }
+  }
+{% endaction %}
+```
+
+Common action types:
+
+* `shopify`: Interact with Shopify Admin API (GraphQL or REST)
+* `http`: Call external APIs
+* `email`: Send emails with templates and attachments
+* `files`: Generate PDFs, CSVs, ZIPs
+* `ftp`: Upload files to FTP/SFTP servers
+* `cache`: Store/retrieve data across task runs
+* `event`: Trigger custom events
+
+#### Responding to Action Results
+
+Tasks can subscribe to `mechanic/actions/perform` to handle action results asynchronously. Use `__perform_event: false` to skip generating follow-up events for specific actions.
+
+## GitBook Formatting Conventions
+
+### Hints
+
+```markdown
+{% hint style="info" %}
+Informational message
+{% endhint %}
+
+{% hint style="warning" %}
+Warning message
+{% endhint %}
+```
+
+### Tabs
+
+```markdown
+{% tabs %}
+{% tab title="Liquid" %}
+Code example
+{% endtab %}
+
+{% tab title="JSON" %}
+Output example
+{% endtab %}
+{% endtabs %}
+```
+
+### Code Blocks
+
+Always add spacing around code blocks:
+
+```markdown
+{% tab title="Example" %}
+(blank line)
+```liquid
+code here
+```
+(blank line)
+{% endtab %}
+```
+
+This spacing is critical for GitBook rendering. Recent commits show ongoing maintenance to fix formatting issues.
+
+## Documentation Patterns
+
+### File Naming
+
+* Use kebab-case: `working-with-external-apis.md`
+* READMEs serve as index pages for directories
+* Keep URLs stable (files are referenced from external sources)
+
+### Content Organization
+
+* Start with high-level concepts before details
+* Use examples extensively (Liquid + JSON output in tabs)
+* Cross-reference related documentation with relative links
+* Include "Learn more" sections with links to deeper content
+
+### Common Sections
+
+* **Description**: What the feature/concept is
+* **Usage**: How to use it (with examples)
+* **Options/Parameters**: Available configuration
+* **Examples**: Real-world use cases
+* **Related**: Links to related documentation
+
+## Important Constraints
+
+1. **No Build Process**: This is a pure documentation repository with no build tools or dependencies. Changes are published directly through GitBook.
+
+2. **GitBook Integration**: The repository is connected to GitBook, which manages publishing. Do not modify `.gitbook/` directory contents.
+
+3. **SUMMARY.md**: This file defines the table of contents for GitBook. Update it when adding new documentation files.
+
+4. **External References**: This documentation is referenced by:
+   - The Mechanic web application (docs.mechanic.dev)
+   - The task library (tasks.mechanic.dev)
+   - Community resources
+   - API documentation
+
+   Avoid breaking links or moving files without redirects.
+
+5. **Shopify API Versions**: Document Shopify API patterns that work across versions. The platform supports multiple API versions simultaneously.
+
+## Writing Guidelines
+
+### Git Commits
+
+When creating commits in this repository:
+
+* Use clear, descriptive commit messages
+* Do not include Claude Code attribution or co-author tags
+* Focus on what changed and why
+
+### For New Documentation
+
+1. Follow existing file structure and naming patterns
+2. Use GitBook formatting (hints, tabs) consistently
+3. Include practical examples with both input and output
+4. Cross-reference related concepts
+5. Update SUMMARY.md to include new files
+6. Add spacing around code blocks for GitBook compatibility
+
+### For Updates
+
+1. Preserve existing URLs and file paths
+2. Maintain GitBook formatting
+3. Test that tabs and hints render correctly
+4. Check for broken internal links
+5. Verify code examples are accurate
+
+### Code Examples
+
+* Use Liquid for task code examples
+* Show both code and expected output in tabs
+* Include error cases and edge cases
+* Demonstrate Mechanic-specific filters and tags
+* Reference Shopify GraphQL API patterns
+
+## Common Tasks
+
+### Adding New Documentation
+
+1. Create markdown file in appropriate directory
+2. Add entry to SUMMARY.md in correct section
+3. Use GitBook formatting conventions
+4. Include cross-references to related docs
+5. Test rendering by checking spacing around code blocks
+
+### Updating Shopify API Examples
+
+1. Verify API version compatibility
+2. Test GraphQL queries in Shopify GraphiQL explorer
+3. Show both query and response in tabs
+4. Document any required permissions
+5. Link to core/shopify/api-versions.md if version-specific
+
+### Fixing Formatting Issues
+
+Recent commits show common formatting fixes:
+
+* Add spacing around code blocks in tabs
+* Normalize tab structures for GitBook
+* Fix Liquid syntax highlighting
+* Ensure code fences are properly closed

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,6 +13,7 @@
 * [🧑‍💻 Task library](resources/task-library/README.md)
   * [Contributing](resources/task-library/contributing.md)
   * [Requesting](resources/task-library/requesting.md)
+* [🤖 Mechanic MCP Server](platform/mcp.md)
 * [🚀 Slack community](resources/slack.md)
 * [🤝 Partner directory](https://partners.mechanic.dev)
 * [🧠 Tutorials](resources/tutorials/README.md)

--- a/ai.md
+++ b/ai.md
@@ -1,8 +1,12 @@
 # 🤖 "I need help with my AI-written task!"
 
-AI thrives on good examples. Our task library — [tasks.mechanic.dev](https://tasks.mechanic.dev/) — is full of good examples. **Connect your AI assistant directly to our task library and documentation using the [Mechanic MCP Server](platform/mcp.md) — it's the best way to help your AI understand Mechanic.**
+{% hint style="info" %}
+**Connect your AI assistant directly to our task library and documentation using the [Mechanic MCP Server](platform/mcp.md) — it's the best way to help your AI understand Mechanic.**
+
+AI thrives on good examples. Our task library — [tasks.mechanic.dev](https://tasks.mechanic.dev/) — is full of good examples.
 
 And if you get too stuck, hire a human. :) We've got those at [partners.mechanic.dev](https://partners.mechanic.dev/).
+{% endhint %}
 
 ***
 

--- a/ai.md
+++ b/ai.md
@@ -1,6 +1,6 @@
 # 🤖 "I need help with my AI-written task!"
 
-AI thrives on good examples. Our task library — [tasks.mechanic.dev](https://tasks.mechanic.dev/) — is full of good examples.
+AI thrives on good examples. Our task library — [tasks.mechanic.dev](https://tasks.mechanic.dev/) — is full of good examples. **Connect your AI assistant directly to our task library and documentation using the [Mechanic MCP Server](platform/mcp.md) — it's the best way to help your AI understand Mechanic.**
 
 And if you get too stuck, hire a human. :) We've got those at [partners.mechanic.dev](https://partners.mechanic.dev/).
 

--- a/platform/mcp.md
+++ b/platform/mcp.md
@@ -1,0 +1,285 @@
+# Mechanic MCP Server
+
+Connect your AI assistant to Mechanic's task library and documentation. The Mechanic Model Context Protocol (MCP) server enables your AI assistant to search tasks, explore documentation, and fetch task code.
+
+***
+
+## How it works
+
+Your AI assistant uses the MCP server to read and interact with Mechanic's resources:
+
+1. Ask your AI assistant to help with Mechanic task development or automation questions.
+2. The assistant searches Mechanic's task library and documentation based on your prompt.
+3. The MCP server provides access to 350+ pre-built tasks and comprehensive Mechanic documentation, so your assistant can provide accurate code, solutions, and guidance based on current best practices.
+
+***
+
+## Requirements
+
+Before you set up the Mechanic MCP server, make sure you have:
+
+* **Node.js 18 or higher** installed on your system.
+* An **AI development tool** that supports MCP, such as Claude Desktop, Claude Code, Cursor, Codex CLI, or Gemini CLI.
+
+***
+
+## What you can ask your AI assistant
+
+After you set up the MCP server, you can ask your AI assistant questions like:
+
+* "Find tasks that auto-tag orders"
+* "How do I subscribe to Shopify product creation events?"
+* "Show me the code for the 'Auto-tag customers by order tier' task"
+* "What tasks use the bulk operations API?"
+* "How do I use the cache action in Mechanic?"
+* "Find similar tasks to 'email customer when order is fulfilled'"
+* "Write a task that sends an email when inventory gets low"
+
+Your AI assistant will use the MCP server to search Mechanic's task library and documentation when providing responses.
+
+***
+
+## Available resources
+
+The MCP server provides access to:
+
+* **350+ pre-built automation tasks** from [tasks.mechanic.dev](https://tasks.mechanic.dev)
+* **Complete Mechanic documentation** from [learn.mechanic.dev](https://learn.mechanic.dev)
+* Task subscriptions, options, and full Liquid scripts
+* Documentation on Liquid templating, actions, events, and integrations
+
+***
+
+## Set up the server
+
+The server runs locally in your development environment and doesn't require authentication.
+
+### Step 1: Configure your AI development tool
+
+Add configuration code that tells your AI tool how to connect to and use the Mechanic MCP server. This configuration enables your AI assistant to automatically access Mechanic's task library and documentation when you ask questions.
+
+#### Claude Desktop and Claude Code
+
+1. For **Claude Desktop**, open the app and access your configuration file through settings. For **Claude Code**, the configuration is managed through the same JSON format.
+
+2. Add this configuration to your MCP servers section:
+
+{% tabs %}
+{% tab title="Configuration" %}
+
+```json
+{
+  "mcpServers": {
+    "mechanic-mcp": {
+      "command": "npx",
+      "args": ["-y", "@lightward/mechanic-mcp@latest"]
+    }
+  }
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+For more information, read the [Claude Desktop MCP guide](https://modelcontextprotocol.io/quickstart/user).
+{% endhint %}
+
+3. Save your configuration and restart Claude Desktop or Claude Code.
+
+#### Cursor
+
+1. Open Cursor and go to **Cursor** > **Settings** > **Cursor Settings** > **Tools and integrations** > **New MCP server**.
+
+2. Add this configuration to your MCP servers:
+
+{% tabs %}
+{% tab title="Configuration" %}
+
+```json
+{
+  "mcpServers": {
+    "mechanic-mcp": {
+      "command": "npx",
+      "args": ["-y", "@lightward/mechanic-mcp@latest"]
+    }
+  }
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+For more information, see the [Cursor MCP documentation](https://docs.cursor.com/context/model-context-protocol).
+{% endhint %}
+
+3. Save your configuration and restart Cursor.
+
+#### Codex CLI
+
+1. Add this configuration to your `~/.codex/config.toml` file:
+
+{% tabs %}
+{% tab title="Configuration" %}
+
+```toml
+[mcp_servers.mechanic-mcp]
+command = "npx"
+args = ["-y", "@lightward/mechanic-mcp@latest"]
+```
+
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+Codex uses TOML format with `mcp_servers` (snake_case) instead of JSON with `mcpServers` (camelCase).
+{% endhint %}
+
+2. Restart Codex to load the new MCP server configuration.
+
+#### Gemini CLI
+
+1. Add this configuration using the Gemini CLI:
+
+{% tabs %}
+{% tab title="Configuration" %}
+
+```json
+{
+  "mcpServers": {
+    "mechanic-mcp": {
+      "command": "npx",
+      "args": ["-y", "@lightward/mechanic-mcp@latest"]
+    }
+  }
+}
+```
+
+{% endtab %}
+{% endtabs %}
+
+{% hint style="info" %}
+By default, this adds the server to your project configuration. To make it available across all projects, add the `--scope user` flag. For more information, see the [Gemini CLI MCP documentation](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html).
+{% endhint %}
+
+2. Restart Gemini CLI to load the new MCP server configuration.
+
+***
+
+## Available tools
+
+The Mechanic MCP server provides the following tools:
+
+### `search_tasks`
+
+Search across Mechanic's task library to find tasks matching your query. Returns task titles, descriptions, tags, subscriptions, and public URLs.
+
+Best for discovering existing automation solutions before building custom tasks. Results include subscription event topics, task options, and tags for filtering.
+
+**Parameters:**
+
+* `query` (required): Search terms to match against task titles, descriptions, and content
+* `limit` (optional): Maximum number of results to return (default: 10, max: 50)
+* `offset` (optional): Number of results to skip for pagination (default: 0)
+* `tags` (optional): Filter by task tags
+* `subscriptions` (optional): Filter by event subscription topics
+* `fuzzy` (optional): Enable fuzzy matching for typo tolerance
+* `fuzzyMaxEdits` (optional): Maximum edit distance for fuzzy matching (max: 2)
+
+***
+
+### `search_docs`
+
+Search across all Mechanic documentation to find relevant pages matching your query. Returns documentation titles, paths, and public URLs.
+
+Best for learning about Mechanic concepts, Liquid templating, actions, and platform features. Returns quick results from across the entire documentation site.
+
+**Parameters:**
+
+* `query` (required): Search terms to match against documentation content
+* `limit` (optional): Maximum number of results to return (default: 10, max: 50)
+* `offset` (optional): Number of results to skip for pagination (default: 0)
+* `fuzzy` (optional): Enable fuzzy matching for typo tolerance
+
+***
+
+### `get_task`
+
+Retrieve complete task details including subscriptions, Liquid script, options, and JavaScript blocks. Use this to see the full implementation of a specific task.
+
+**Parameters:**
+
+* `id` (required): Task handle or ID (e.g., "auto-tag-customers-by-sales-channel" or "task:auto-tag-customers-by-sales-channel")
+
+**Returns:**
+
+* Task metadata (name, tags, URL)
+* Event subscriptions and subscription template
+* Complete Liquid script
+* Task options with defaults
+* Online store JavaScript (if present)
+* Order status JavaScript (if present)
+
+{% hint style="info" %}
+When sharing task code, return only the relevant parts (subscriptions and script), not the full JSON export. Always include the public task URL.
+{% endhint %}
+
+***
+
+### `get_doc`
+
+Retrieve the full content of a documentation page. Provides complete documentation context without chunking.
+
+**Parameters:**
+
+* `id` (required): Documentation ID from search results (e.g., "doc:core/tasks/code/action-objects.md")
+
+**Returns:**
+
+* Full markdown content
+* Documentation title and path
+* Public documentation URL
+
+{% hint style="info" %}
+Documentation pages are also available as MCP resources through the `mechanic-docs://` URI scheme.
+{% endhint %}
+
+***
+
+### `similar_tasks`
+
+Find tasks related to a specific task by analyzing shared tags, event subscriptions, and title similarity. Useful for discovering alternative approaches or complementary automations.
+
+**Parameters:**
+
+* `handle` (required): Task handle or ID to find similar tasks for
+* `limit` (optional): Maximum number of similar tasks to return (default: 10)
+
+***
+
+### `refresh_index`
+
+Refresh and rebuild the search index from bundled data. Generally not needed as the server includes pre-built indexes.
+
+***
+
+## Usage best practices
+
+When working with your AI assistant and the Mechanic MCP server:
+
+* **Discover before building**: Search for existing tasks before creating custom solutions. The library contains 350+ battle-tested tasks.
+* **Use GraphQL**: Prefer Shopify's GraphQL Admin API in task code. REST is deprecated in Mechanic.
+* **Reference public URLs**: Always cite tasks using their public URLs (tasks.mechanic.dev) and docs using learn.mechanic.dev URLs.
+* **Get full task details**: Use `get_task` to see complete implementations, including subscriptions, scripts, and options.
+* **Find related work**: Use `similar_tasks` to discover alternative approaches or complementary automations.
+
+***
+
+## Related resources
+
+* [Task library](../resources/task-library/) - Browse and contribute to Mechanic's task library
+* [Writing tasks](../core/tasks/) - Learn how to write Mechanic tasks
+* [Liquid templating](liquid/) - Mechanic's Liquid implementation
+* [Actions](../core/actions/) - Available action types for tasks
+* [Events and subscriptions](../core/events/) - Understanding Mechanic's event system

--- a/platform/mcp.md
+++ b/platform/mcp.md
@@ -61,15 +61,19 @@ Add configuration code that tells your AI tool how to connect to and use the Mec
 #### Claude Desktop and Claude Code
 
 **For Claude Desktop:**
+
 1. Open the app and access your configuration file through settings
 2. Add the JSON configuration below to your MCP servers section
 3. Save and restart Claude Desktop
 
 **For Claude Code:**
+
 1. Run this command in your terminal:
+
    ```bash
    claude mcp add --scope user --transport stdio mechanic-mcp -- npx -y @lightward/mechanic-mcp@latest
    ```
+
 2. Restart Claude Code to load the server
 
 **Manual JSON configuration (both):**
@@ -122,7 +126,7 @@ For more information, read the [Claude Desktop MCP guide](https://modelcontextpr
 For more information, see the [Cursor MCP documentation](https://docs.cursor.com/context/model-context-protocol).
 {% endhint %}
 
-3. Save your configuration and restart Cursor.
+1. Save your configuration and restart Cursor.
 
 #### Codex CLI
 
@@ -144,7 +148,7 @@ args = ["-y", "@lightward/mechanic-mcp@latest"]
 Codex uses TOML format with `mcp_servers` (snake_case) instead of JSON with `mcpServers` (camelCase).
 {% endhint %}
 
-2. Restart Codex to load the new MCP server configuration.
+1. Restart Codex to load the new MCP server configuration.
 
 #### Gemini CLI
 
@@ -171,7 +175,7 @@ Codex uses TOML format with `mcp_servers` (snake_case) instead of JSON with `mcp
 By default, this adds the server to your project configuration. To make it available across all projects, add the `--scope user` flag. For more information, see the [Gemini CLI MCP documentation](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html).
 {% endhint %}
 
-2. Restart Gemini CLI to load the new MCP server configuration.
+1. Restart Gemini CLI to load the new MCP server configuration.
 
 ***
 

--- a/platform/mcp.md
+++ b/platform/mcp.md
@@ -60,9 +60,19 @@ Add configuration code that tells your AI tool how to connect to and use the Mec
 
 #### Claude Desktop and Claude Code
 
-1. For **Claude Desktop**, open the app and access your configuration file through settings. For **Claude Code**, the configuration is managed through the same JSON format.
+**For Claude Desktop:**
+1. Open the app and access your configuration file through settings
+2. Add the JSON configuration below to your MCP servers section
+3. Save and restart Claude Desktop
 
-2. Add this configuration to your MCP servers section:
+**For Claude Code:**
+1. Run this command in your terminal:
+   ```bash
+   claude mcp add --scope user --transport stdio mechanic-mcp -- npx -y @lightward/mechanic-mcp@latest
+   ```
+2. Restart Claude Code to load the server
+
+**Manual JSON configuration (both):**
 
 {% tabs %}
 {% tab title="Configuration" %}
@@ -84,8 +94,6 @@ Add configuration code that tells your AI tool how to connect to and use the Mec
 {% hint style="info" %}
 For more information, read the [Claude Desktop MCP guide](https://modelcontextprotocol.io/quickstart/user).
 {% endhint %}
-
-3. Save your configuration and restart Claude Desktop or Claude Code.
 
 #### Cursor
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the Mechanic MCP Server, which enables AI assistants to access the task library and documentation.

## Changes

### New Documentation
- **platform/mcp.md**: Complete MCP server guide
  - Setup instructions for Claude Desktop, Claude Code, Cursor, Codex CLI, and Gemini CLI
  - Documentation for all 6 MCP tools (search_tasks, search_docs, get_task, get_doc, similar_tasks, refresh_index)
  - Usage best practices and examples
  - Correctly scoped to focus on search/exploration, not task writing

### Updates
- **ai.md**: Added assertive MCP recommendation while preserving Isaac's original signed content
- **SUMMARY.md**: Added MCP Server to Resources section (after Task library) with 🤖 emoji
- **.gitignore**: Ignore lowercase claude.md at root
- **CLAUDE.md**: Added git commit guidelines (no Claude Code attribution)

## Positioning

The MCP server is positioned as a tool for accessing and exploring Mechanic's 350+ tasks and documentation - NOT as a solution for custom task writing or library contributions. This keeps expectations appropriate while providing value to AI users.