### PR TITLE
Document __meta control parameter and simplify examples

### DIFF
--- a/core/actions/README.md
+++ b/core/actions/README.md
@@ -11,6 +11,8 @@ To inspect and respond to the results of an HTTP action, add a task subscription
 
 If you don't need the follow-up event for a particular action, add `__perform_event: false` to that action to skip emitting mechanic/actions/perform while still performing the action.
 
+To attach meta while using any of the action tag syntaxes, add `__meta` and Mechanic will move that value into the action's meta field.
+
 Learn more: [Responding to action results](../../techniques/responding-to-action-results.md)
 {% endhint %}
 

--- a/core/actions/event.md
+++ b/core/actions/event.md
@@ -97,17 +97,14 @@ This example uses the `run_at` option to run the task at a later scheduled time.
 
 This task emails a customer daily until their order is paid. It works by scheduling a follow-up run of the same task, one day in the future, using the `run_at` option.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```liquid
 shopify/orders/create
 user/orders/unpaid_reminder
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```javascript
 {% if event.preview %}
@@ -144,24 +141,19 @@ user/orders/unpaid_reminder
 {% endunless %}
 ```
 
-{% endtab %}
-{% endtabs %}
 
 #### Using subscription offsets
 
 This task emails a customer daily until their order is paid. It works by firing the follow-up event immediately, using a subscription offset to respond to it a day later.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```liquid
 shopify/orders/create
 user/orders/unpaid_reminder+1.day
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```javascript
 {% if event.preview %}
@@ -196,6 +188,3 @@ user/orders/unpaid_reminder+1.day
   {% endaction %}
 {% endunless %}
 ```
-
-{% endtab %}
-{% endtabs %}

--- a/core/actions/files.md
+++ b/core/actions/files.md
@@ -32,17 +32,14 @@ A Files action returns an object having the same keys (i.e. filenames) as its in
 
 This task generates a variety of files. It then re-invokes itself (via mechanic/actions/perform), sending an email containing links to each of the generated files.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```liquid
 mechanic/user/trigger
 mechanic/actions/perform
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```liquid
 {% if event.topic == "mechanic/user/trigger" %}
@@ -90,6 +87,3 @@ mechanic/actions/perform
   {% endaction %}
 {% endif %}
 ```
-
-{% endtab %}
-{% endtabs %}

--- a/core/actions/ftp.md
+++ b/core/actions/ftp.md
@@ -159,17 +159,14 @@ Uploads are processed before downloads; it can be useful to test by uploading a 
 
 This task compiles all SKUs with their titles and prices, and uploads it as a CSV every night or on demand.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 mechanic/scheduler/daily
 mechanic/user/trigger
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```liquid
 {% assign csv_rows = array %}
@@ -207,6 +204,3 @@ mechanic/user/trigger
   }
 {% endaction %}
 ```
-
-{% endtab %}
-{% endtabs %}

--- a/core/actions/http.md
+++ b/core/actions/http.md
@@ -136,17 +136,14 @@ As with all runs, HTTP action errors are subject to [Mechanic's retry policy](..
 
 This task prompts the user for text input, and submits it to a public API that returns everything submitted to it. The task then re-invokes itself, using the [Echo](echo.md) action to display the response status, content type, and body.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 mechanic/user/text
 mechanic/actions/perform
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```liquid
 {% if event.topic == "mechanic/user/text" %}
@@ -164,6 +161,3 @@ mechanic/actions/perform
     response_body: action.run.result.body %}
 {% endif %}
 ```
-
-{% endtab %}
-{% endtabs %}

--- a/core/events/parent-and-child-events.md
+++ b/core/events/parent-and-child-events.md
@@ -13,17 +13,14 @@ When viewing any given event in Mechanic, look in the event details to find any 
 
 ## Example
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 mechanic/user/trigger
 user/fan/out
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```liquid
 {% assign n = event.data | default: 0 | times: 1 %}
@@ -42,9 +39,6 @@ user/fan/out
   {% action "echo", event_data: event.data, parent_event_data: event.parent.data %}
 {% endif %}
 ```
-
-{% endtab %}
-{% endtabs %}
 
 As written, this task will "fan out": it will generate 1 child event, which will then generate 2 child events, each of which will then generate 3 child events, and each of those will then generate 4 child events, and finally, each of those events will generate 5 child events of their own. The result: 154 events, created with a single click. 💪
 

--- a/core/shopify/read/bulk-operations.md
+++ b/core/shopify/read/bulk-operations.md
@@ -50,19 +50,14 @@ This technique allows the array of objects to be quickly filtered by type:
 
 ## Example
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 mechanic/user/trigger
 mechanic/shopify/bulk_operation
 ```
 
-{% endtab %}
-{% endtabs %}
-
-{% tabs %}
-{% tab title="Code" %}
+**Code**
 
 ```javascript
 {% if event.topic == "mechanic/user/trigger" %}
@@ -102,9 +97,6 @@ mechanic/shopify/bulk_operation
   {% log emails: emails %}
 {% endif %}
 ```
-
-{% endtab %}
-{% endtabs %}
 
 ### More examples
 

--- a/core/tasks/README.md
+++ b/core/tasks/README.md
@@ -16,16 +16,13 @@ Working on getting better at task-writing? See [Practicing writing tasks](../../
 
 This very basic task subscribes to shopify/customers/create, and renders an [Email action](../actions/email.md), using an email subject and body taken from user-configured [options](options/).
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 shopify/customers/create
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```liquid
 {% action "email" %}
@@ -38,15 +35,10 @@ shopify/customers/create
 {% endaction %}
 ```
 
-{% endtab %}
-
-{% tab title="Export" %}
+**Export**
 
 ```
 {"name":"Customer signup alerts","options":{"email_recipient__email_required":"aesha@example.com","email_subject__required":"A new customer has signed up: {{ customer.email }}","email_body__multiline_required":"Hi! View this customer's details online:\n\nhttps://{{ shop.domain }}/admin/customers/{{ customer.id }}\n\n-Mechanic"},"script":"{% action \"email\" %}\n  {\n    \"to\": {{ options.email_recipient__email_required | json }},\n    \"subject\": {{ options.email_subject__required | json }},\n    \"body\": {{ options.email_body__multiline_required | newline_to_br | json }},\n    \"from_display_name\": {{ shop.name | json }}\n  }\n{% endaction %}","subscriptions":["shopify/customers/create"],"online_store_javascript":null,"order_status_javascript":null,"docs":null,"subscriptions_template":"shopify/customers/create","shopify_api_version":"2022-04","liquid_profiling":false,"perform_action_runs_in_sequence":false,"halt_action_run_sequence_on_error":false,"preview_event_definitions":[]}
 ```
-
-{% endtab %}
-{% endtabs %}
 
 ![](<../../.gitbook/assets/Screen Shot 2022-04-01 at 7.14.46 PM.png>)

--- a/core/tasks/code/action-objects.md
+++ b/core/tasks/code/action-objects.md
@@ -38,7 +38,10 @@ Action **options** vary by action type. Depending on the action type, its option
 
 #### Control parameters
 
-Mechanic reserves a small set of double-underscore parameters for controlling how an action is handled. The current control parameter is `__perform_event`. Set it to `false` to skip emitting the follow-up `mechanic/actions/perform` event for that specific action (the default is to emit it).
+Mechanic reserves a small set of double-underscore parameters for controlling how an action is handled. These control parameters include:
+
+- `__perform_event`, which you can set to `false` to skip emitting the follow-up `mechanic/actions/perform` event for that specific action (the default is to emit it).
+- `__meta`, which moves the provided value into the action's `meta` field so you can attach meta data while using any action tag syntax.
 
 Examples:
 
@@ -47,14 +50,51 @@ Examples:
 ```
 
 ```liquid
-{%- action "shopify", __perform_event: false -%}
-  mutation { shop { id } }
-{%- endaction -%}
+{%- assign meta = hash -%}
+{%- assign meta["source"] = "cache" -%}
+{%- action "cache", "set", "foo", "bar", __meta: meta -%}
 ```
 
 ### Meta
 
 Actions may optionally include **meta** information, annotating the action with any JSON value.
+
+When you're using the action tag, you can attach meta in a few ways:
+
+- Provide a `meta` object alongside `options` when you're supplying an options hash.
+- Supply meta as the second positional argument when the options are a hash.
+- Use the `__meta` control parameter with any action tag syntax to move the value into the action's meta.
+
+```liquid
+{%- assign options = hash -%}
+{%- assign options["method"] = "post" -%}
+{%- assign options["url"] = "https://postman-echo.com/post" -%}
+{%- assign meta = hash -%}
+{%- assign meta["mode"] = "initial_request" -%}
+{%- action "http", options: options, meta: meta -%}
+```
+
+```liquid
+{%- assign options = hash -%}
+{%- assign options["method"] = "post" -%}
+{%- assign options["url"] = "https://postman-echo.com/post" -%}
+{%- assign meta = hash -%}
+{%- assign meta["mode"] = "initial_request" -%}
+{%- action "http", options, meta -%}
+```
+
+```liquid
+{%- assign meta = hash -%}
+{%- assign meta["note"] = "graphql" -%}
+{%- action "shopify", __meta: meta -%}
+  mutation {
+    tagsAdd(id: "gid://shopify/Customer/1234567890", tags: ["vip"]) {
+      node { id }
+      userErrors { field message }
+    }
+  }
+{%- endaction -%}
+```
 
 This information could be purely for record-keeping, making it easy to determine why an action was rendered, or to add helpful context:
 

--- a/core/tasks/previews/README.md
+++ b/core/tasks/previews/README.md
@@ -116,16 +116,11 @@ Branching a task like this has two problems:
 {% endif %}
 ```
 
-{% endtab %}
-
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 shopify/orders/create
 ```
-
-{% endtab %}
-{% endtabs %}
 
 ### Dynamic preview actions
 

--- a/platform/liquid/tags/action.md
+++ b/platform/liquid/tags/action.md
@@ -2,7 +2,7 @@
 
 The **action tag** renders an [**action object**](../../../core/tasks/code/action-objects.md) in JSON, which in turn defines work to be performed by an [**action**](../../../core/actions/).
 
-Mechanic also recognizes certain double-underscore control parameters on actions. The most common is `__perform_event: false`, which tells Mechanic _not_ to emit the follow-up `mechanic/actions/perform` event for that action. Control parameters work with every syntax shown below.
+Mechanic also recognizes certain double-underscore control parameters on actions. For example, `__perform_event: false` tells Mechanic _not_ to emit the follow-up `mechanic/actions/perform` event for that action, and `__meta` lets you attach meta data without writing an explicit `meta` block. Control parameters work with every syntax shown below.
 
 ## Syntax
 
@@ -14,7 +14,7 @@ As with nearly all Liquid tags, the action tag supports Liquid variables. This m
 
 ### Block syntax
 
-This usage style offers the lightest form of abstraction, in that it only abstracts away `{ "action": ... }` layer of the resulting JSON object. Use this style when it's necessary to also provide [meta information for an action](../../../core/tasks/code/action-objects.md#meta), in addition to the action's type and options.
+This usage style offers the lightest form of abstraction, in that it only abstracts away `{ "action": ... }` layer of the resulting JSON object. It's one option for specifying [meta information for an action](../../../core/tasks/code/action-objects.md#meta) alongside the action's type and options, but you can just as easily add meta to the other syntaxes using `meta:` or the `__meta` control parameter (see below).
 
 ```liquid
 {% action %}
@@ -83,32 +83,38 @@ tag.
 
 ## Control parameters
 
-Control parameters adjust how Mechanic handles the resulting action. Add them inline with a double-underscore key. Today, `__perform_event: false` is available to skip emitting the follow-up `mechanic/actions/perform` event for that action while still running the action itself.
+Control parameters adjust how Mechanic handles the resulting action. Add them inline with a double-underscore key. Two are available today:
 
-{% tabs %}
-{% tab title="Positional" %}
+- `__perform_event: false` skips emitting the follow-up `mechanic/actions/perform` event for that action while still running the action itself.
+- `__meta` attaches meta to the action, even when you're using the tag syntaxes instead of an explicit `meta` object.
+
+**Positional options**
 
 ```liquid
-{% action "cache", "set", "foo", "bar", __perform_event: false %}
+{% assign meta = hash %}
+{% assign meta["source"] = "cache" %}
+{% action "cache", "set", "foo", "bar", __meta: meta, __perform_event: false %}
 ```
 
-{% endtab %}
-
-{% tab title="Mapped" %}
+**Mapped options**
 
 ```liquid
-{% action "http", method: "get", url: "https://postman-echo.com/get", __perform_event: false %}
+{% assign meta = hash %}
+{% assign meta["note"] = "http" %}
+{% action "http", method: "get", url: "https://postman-echo.com/get", __meta: meta %}
 ```
 
-{% endtab %}
-
-{% tab title="Shopify GraphQL" %}
+**Shopify GraphQL**
 
 ```liquid
-{% action "shopify", __perform_event: false %}
-  mutation { shop { id } }
+{% assign meta = hash %}
+{% assign meta["level"] = "info" %}
+{% action "shopify", __meta: meta %}
+  mutation {
+    tagsAdd(id: "gid://shopify/Customer/1234567890", tags: ["vip"]) {
+      node { id }
+      userErrors { field message }
+    }
+  }
 {% endaction %}
 ```
-
-{% endtab %}
-{% endtabs %}

--- a/techniques/monitoring.md
+++ b/techniques/monitoring.md
@@ -36,17 +36,14 @@ It's generally preferable to use an external service for this sort of thing, rat
 
 When run manually, this task sets an auto-expiring flag in the Mechanic cache, set to expire in ten minutes. Separately, this task checks for the presence of that flag every ten minutes. If the flag is missing (indicating that the task was not run manually in the last ten minutes), the task sends an email.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 mechanic/scheduler/10min
 mechanic/user/trigger
 ```
 
-{% endtab %}
-
-{% tab title="Code" %}
+**Code**
 
 ```liquid
 {% if event.topic contains "mechanic/scheduler" %}
@@ -66,6 +63,3 @@ mechanic/user/trigger
   {% action "cache", "setex", "monitor-10min", 600, now %}
 {% endif %}
 ```
-
-{% endtab %}
-{% endtabs %}

--- a/techniques/responding-to-action-results.md
+++ b/techniques/responding-to-action-results.md
@@ -41,19 +41,14 @@ Mechanic will step in and forcibly fail subsequent task runs that contain result
 
 This example cycles between three different modes of operation, depending on the [meta information](../core/tasks/code/action-objects.md#meta) recorded in the action definition. And, by checking on `action.run.ok` at the very beginning, the task is also able to "break" into failure-handling mode, in which an email is sent to an administrator.
 
-{% tabs %}
-{% tab title="Subscriptions" %}
+**Subscriptions**
 
 ```
 mechanic/user/trigger
 mechanic/actions/perform
 ```
 
-{% endtab %}
-{% endtabs %}
-
-{% tabs %}
-{% tab title="Code" %}
+**Code**
 
 ```javascript
 {% if action.run.ok == false %}
@@ -96,6 +91,3 @@ mechanic/actions/perform
   {% action "echo", "done" %}
 {% endif %}
 ```
-
-{% endtab %}
-{% endtabs %}


### PR DESCRIPTION
## Summary
- document the new __meta control parameter across action docs
- clarify meta can be attached with any action syntax, not just block
- replace tabbed subscription/code layouts with stacked sections for readability

## Testing
- not run (docs only)
