### PR TITLE
Document run-link inputs

### DIFF
--- a/core/shopify/admin-action-links.md
+++ b/core/shopify/admin-action-links.md
@@ -89,7 +89,7 @@ Using a Shopify admin action link brings the user to the page shown below, in wh
 
 After selecting a processing mode, select from the available compatible tasks – i.e. from enabled tasks that subscribe to a relevant event topic. You can send this event to one or more tasks that subscribe to the correct event topic.
 
-If the selected task includes [User Form](../tasks/user-form.md) options (`__userform`), you will be prompted to fill them out before running. These values are available in Liquid as `input.<name>`. For batch mode, the same input values apply to all selected resources.
+If the selected task includes [User Form](../tasks/user-form.md) options (`__userform`), you will be prompted to fill them out before running. These values are available in Liquid as `input.<name>`. This input form only appears when exactly one task is selected. For batch mode, the same input values apply to all selected resources.
 
 ## Task usage
 

--- a/core/shopify/admin-action-links.md
+++ b/core/shopify/admin-action-links.md
@@ -89,7 +89,7 @@ Using a Shopify admin action link brings the user to the page shown below, in wh
 
 After selecting a processing mode, select from the available compatible tasks – i.e. from enabled tasks that subscribe to a relevant event topic. You can send this event to one or more tasks that subscribe to the correct event topic.
 
-If the selected task includes user form options (`__userform`), you will be prompted to fill them out before running. These values are available in Liquid as `input.<name>`. For batch mode, the same input values apply to all selected resources.
+If the selected task includes [User Form](../tasks/user-form.md) options (`__userform`), you will be prompted to fill them out before running. These values are available in Liquid as `input.<name>`. For batch mode, the same input values apply to all selected resources.
 
 ## Task usage
 

--- a/core/shopify/admin-action-links.md
+++ b/core/shopify/admin-action-links.md
@@ -89,6 +89,8 @@ Using a Shopify admin action link brings the user to the page shown below, in wh
 
 After selecting a processing mode, select from the available compatible tasks – i.e. from enabled tasks that subscribe to a relevant event topic. You can send this event to one or more tasks that subscribe to the correct event topic.
 
+If the selected task includes user form options (`__userform`), you will be prompted to fill them out before running. These values are available in Liquid as `input.<name>`. For batch mode, the same input values apply to all selected resources.
+
 ## Task usage
 
 To qualify a task to receive these events, subscribe to an event topic from the [Supported resources](admin-action-links.md#supported-resources) table above.

--- a/core/tasks/options/README.md
+++ b/core/tasks/options/README.md
@@ -10,7 +10,7 @@ Mechanic flags provide only limited option validation. For anything more advance
 
 Paste any of these into your task code (even inside a `{% comment %}` block) to create an option:
 
-Options flagged with `__userform` will also appear on the **Run task** form for tasks that subscribe to `mechanic/user/form`.
+Options flagged with `__userform` will also appear on the **Run task** form for tasks that subscribe to `mechanic/user/form`, and on the Run tasks page for Shopify admin action links (mechanic/user/{resource} topics). Submitted values are available in Liquid as `input.<name>`.
 
 ```liquid
 {{ options.note }}
@@ -72,7 +72,7 @@ Many flags may be combined with other flags, for more nuanced control.
 
 If no flags are used for an option, an option will be made available as a plain text field, and the option value will be a string.
 
-The special **`userform`** flag does not change the input type or validation; it simply marks an option as one that should appear on the **Run task** form (topic `mechanic/user/form`) in addition to the general task options screen.
+The special **`userform`** flag does not change the input type or validation; it simply marks an option as one that should appear on the **Run task** form (topic `mechanic/user/form`) and the Run tasks page for Shopify admin action links, in addition to the general task options screen.
 
 #### Flags fall into three categories:
 
@@ -140,7 +140,7 @@ Do not put modifiers before the input-type flag (e.g. `options.aggregate__userfo
 | ---------- | ---------- | ---------------------------------------------------------------- |
 | `required` | Any        | Field must be filled before Save.                                |
 | `email`    | `text`     | Adds email placeholder and basic email format check.             |
-| `userform` | Any        | Shows this option on **Run task** form (`mechanic/user/form`).   |
+| `userform` | Any        | Shows this option on **Run task** form (`mechanic/user/form`) and on Shopify admin action link runs.   |
 
 ### 3.3 Auxiliary flags
 

--- a/core/tasks/options/README.md
+++ b/core/tasks/options/README.md
@@ -10,7 +10,7 @@ Mechanic flags provide only limited option validation. For anything more advance
 
 Paste any of these into your task code (even inside a `{% comment %}` block) to create an option:
 
-Options flagged with `__userform` will also appear on the **Run task** form for tasks that subscribe to `mechanic/user/form`, and on the Run tasks page for Shopify admin action links (mechanic/user/{resource} topics). Submitted values are available in Liquid as `input.<name>`.
+Options flagged with `__userform` will also appear on the **Run task** form for tasks that subscribe to `mechanic/user/form`, and on the Run tasks page for Shopify admin action links (mechanic/user/{resource} topics). These are [User Form](../user-form.md) fields, and submitted values are available in Liquid as `input.<name>`.
 
 ```liquid
 {{ options.note }}
@@ -72,7 +72,7 @@ Many flags may be combined with other flags, for more nuanced control.
 
 If no flags are used for an option, an option will be made available as a plain text field, and the option value will be a string.
 
-The special **`userform`** flag does not change the input type or validation; it simply marks an option as one that should appear on the **Run task** form (topic `mechanic/user/form`) and the Run tasks page for Shopify admin action links, in addition to the general task options screen.
+The special **`userform`** flag does not change the input type or validation; it simply marks an option as one that should appear on the **Run task** form (topic `mechanic/user/form`) and the Run tasks page for Shopify admin action links, in addition to the general task options screen. See [User Form](../user-form.md) for details.
 
 #### Flags fall into three categories:
 

--- a/core/tasks/user-form.md
+++ b/core/tasks/user-form.md
@@ -4,7 +4,7 @@ When a task subscribes to the **mechanic/user/form** event topic a "Run task" bu
 
 When the Run Task button is clicked the user is presented with a form that contains any [task options](options/) that have the `_userform` flag.&#x20;
 
-When submitted, an event is generated, to which only this task will respond. The event contains the user's input in its data, making user's input available in `event.data.`
+When submitted, an event is generated, to which only this task will respond. The user's input is available in Liquid as `input.<name>`.
 
 <figure><img src="../../.gitbook/assets/image (1) (1).png" alt=""><figcaption><p>User form on Run Task page</p></figcaption></figure>
 
@@ -25,9 +25,9 @@ During a `mechanic/user/form` event, the ad-hoc values arrive under event.data.
 {% assign level = options.level__select_o1_low_o2_high %}
 
 {% if event.topic == "mechanic/user/form" %}
-  {% # we need to get the value from event data, we don't want the value from the task option %}
-  {% assign big_event = event.data.the_big_event__date_userform %}
-  {% assign color_for_big_event = event.data.color_for_big_event__color_required_userform %}
+  {% # we need to get the value from user input, we don't want the value from the task option %}
+  {% assign big_event = input.the_big_event %}
+  {% assign color_for_big_event = input.color_for_big_event %}
 
 {% endif %}
 
@@ -38,3 +38,5 @@ During a `mechanic/user/form` event, the ad-hoc values arrive under event.data.
 Tip: `event.data` contains the values for the fields you exposed; fall back to\
 `options.*` for everything else.
 {% endhint %}
+
+User form options also appear on the Run tasks page for Shopify admin action links (mechanic/user/{resource} topics). In that context, `input.<name>` is still the recommended way to access user input.

--- a/core/tasks/user-form.md
+++ b/core/tasks/user-form.md
@@ -14,7 +14,7 @@ Click the link button beside the title of the form to copy a link to the form th
 
 ### Getting the user’s input in code
 
-During a `mechanic/user/form` event, the ad-hoc values arrive under event.data.
+During a `mechanic/user/form` event, ad-hoc values are available as `input.<name>`. `event.data` also contains these values for backward compatibility.
 
 ```liquid
 {% # These will appear on the run task user form %}

--- a/platform/events/topics.md
+++ b/platform/events/topics.md
@@ -70,7 +70,7 @@ Not to be confused with events in the User domain, the mechanic/user event subje
 * **mechanic/user/text**\
   When used, adds a "Run task" button to the task itself. This button prompts the user with a multi-line text box. When submitted, an event is generated, to which only this task will respond. The event contains the user's input in its data, making user's input available in `event.data`.
 * **mechanic/user/form**\
-  When used, adds a "Run task" button to the task itself. When Run Task button is clicked they are presented with form that contains any [task options](../../core/tasks/options/) that have the `_userform` flag. When submitted, an event is generated, to which only this task will respond. The user's input is available in Liquid as `input.<name>`.
+  When used, adds a "Run task" button to the task itself. When Run Task button is clicked they are presented with form that contains any [task options](../../core/tasks/options/) that have the `_userform` flag. When submitted, an event is generated, to which only this task will respond. See [User Form](../../core/tasks/user-form.md) for details. The user's input is available in Liquid as `input.<name>`.
 
 The following mechanic/user topics are typically used with [Shopify admin action links](../../core/shopify/admin-action-links.md), and are documented there more fully.
 

--- a/platform/events/topics.md
+++ b/platform/events/topics.md
@@ -70,7 +70,7 @@ Not to be confused with events in the User domain, the mechanic/user event subje
 * **mechanic/user/text**\
   When used, adds a "Run task" button to the task itself. This button prompts the user with a multi-line text box. When submitted, an event is generated, to which only this task will respond. The event contains the user's input in its data, making user's input available in `event.data`.
 * **mechanic/user/form**\
-  When used, adds a "Run task" button to the task itself. When Run Task button is clicked they are presented with form that contains any [task options](../../core/tasks/options/) that have the `_userform` flag. When submitted, an event is generated, to which only this task will respond. The event contains the user's input in its data, making user's input available in `event.data`.
+  When used, adds a "Run task" button to the task itself. When Run Task button is clicked they are presented with form that contains any [task options](../../core/tasks/options/) that have the `_userform` flag. When submitted, an event is generated, to which only this task will respond. The user's input is available in Liquid as `input.<name>`.
 
 The following mechanic/user topics are typically used with [Shopify admin action links](../../core/shopify/admin-action-links.md), and are documented there more fully.
 

--- a/platform/integrations/run-links.md
+++ b/platform/integrations/run-links.md
@@ -53,3 +53,5 @@ Breaking this down, the URL consists of the following:
     ```
 
 Repeat the `ids[]` query parameter as needed, for each relevant resource ID.
+
+If the selected task includes any user form options (`__userform`), the Run tasks page will present those fields. Submitted values are available in Liquid as `input.<name>`. For batch runs, the same input values apply to all selected resources.

--- a/platform/integrations/run-links.md
+++ b/platform/integrations/run-links.md
@@ -54,4 +54,4 @@ Breaking this down, the URL consists of the following:
 
 Repeat the `ids[]` query parameter as needed, for each relevant resource ID.
 
-If the selected task includes any user form options (`__userform`), the Run tasks page will present those fields. Submitted values are available in Liquid as `input.<name>`. For batch runs, the same input values apply to all selected resources.
+If the selected task includes any [User Form](../../core/tasks/user-form.md) options (`__userform`), the Run tasks page will present those fields. Submitted values are available in Liquid as `input.<name>`. For batch runs, the same input values apply to all selected resources.


### PR DESCRIPTION
## Summary
- document run-link inputs for Shopify admin action links
- clarify `input.<name>` usage for user form options
- note batch inputs apply to all selected resources

## Related PRs
- https://github.com/lightward/mechanic-api/pull/2113
- https://github.com/lightward/mechanic-ui/pull/1923
