### PR TITLE
Document user input on admin action links

### DIFF
--- a/core/shopify/admin-action-links.md
+++ b/core/shopify/admin-action-links.md
@@ -89,7 +89,15 @@ Using a Shopify admin action link brings the user to the page shown below, in wh
 
 After selecting a processing mode, select from the available compatible tasks – i.e. from enabled tasks that subscribe to a relevant event topic. You can send this event to one or more tasks that subscribe to the correct event topic.
 
-If the selected task includes [User Form](../tasks/user-form.md) options (`__userform`), you will be prompted to fill them out before running. These values are available in Liquid as `input.<name>`. This input form only appears when exactly one task is selected. For batch mode, the same input values apply to all selected resources.
+### User input (User Form options)
+
+Tasks can opt in to user input on this page by defining [User Form](../tasks/user-form.md) fields. This makes the Run tasks page behave like a lightweight form runner for the selected task.
+
+To enable this, add `__userform` to task options (see [task options](../tasks/options/README.md)). When exactly one task is selected, those fields appear and must be filled in before running.
+
+Submitted values are available in Liquid as `input.<name>` (and in `event.data` for backward compatibility). For batch mode, the same input values apply to all selected resources.
+
+If you need a standalone, shareable form link, subscribe the task to `mechanic/user/form` and use the task-level Run Task button. See [User Form](../tasks/user-form.md) for details.
 
 ## Task usage
 

--- a/core/tasks/options/README.md
+++ b/core/tasks/options/README.md
@@ -10,7 +10,7 @@ Mechanic flags provide only limited option validation. For anything more advance
 
 Paste any of these into your task code (even inside a `{% comment %}` block) to create an option:
 
-Options flagged with `__userform` will also appear on the **Run task** form for tasks that subscribe to `mechanic/user/form`, and on the Run tasks page for Shopify admin action links (mechanic/user/{resource} topics). These are [User Form](../user-form.md) fields, and submitted values are available in Liquid as `input.<name>`.
+Options flagged with `__userform` will also appear on the **Run task** form for tasks that subscribe to `mechanic/user/form`, and on the Run tasks page for Shopify admin action links (mechanic/user/{resource} topics). These are [User Form](../user-form.md) fields, and submitted values are available in Liquid as `input.<name>`. See [Shopify admin action links](../../shopify/admin-action-links.md) for the end-user flow.
 
 ```liquid
 {{ options.note }}

--- a/core/tasks/user-form.md
+++ b/core/tasks/user-form.md
@@ -12,6 +12,15 @@ When submitted, an event is generated, to which only this task will respond. The
 Click the link button beside the title of the form to copy a link to the form that you can share with your users
 {% endhint %}
 
+### Where User Form fields appear
+
+User Form fields show up in:
+
+- The task-level Run Task button for `mechanic/user/form`.
+- The Run tasks page for Shopify admin action links (and equivalent run links) when exactly one task is selected.
+
+See [Shopify admin action links](../shopify/admin-action-links.md) and [Run links](../../platform/integrations/run-links.md) for details.
+
 ### Getting the user’s input in code
 
 During a `mechanic/user/form` event, ad-hoc values are available as `input.<name>`. `event.data` also contains these values for backward compatibility.

--- a/platform/integrations/run-links.md
+++ b/platform/integrations/run-links.md
@@ -55,3 +55,7 @@ Breaking this down, the URL consists of the following:
 Repeat the `ids[]` query parameter as needed, for each relevant resource ID.
 
 If the selected task includes any [User Form](../../core/tasks/user-form.md) options (`__userform`), the Run tasks page will present those fields. Submitted values are available in Liquid as `input.<name>`. For batch runs, the same input values apply to all selected resources.
+
+{% hint style="info" %}
+See [User Form](../../core/tasks/user-form.md) for how to define `__userform` fields, and [Shopify admin action links](../../core/shopify/admin-action-links.md) for the end-user flow.
+{% endhint %}


### PR DESCRIPTION
## Summary
- add a dedicated User input section to admin action links
- explain opt-in via __userform options, input.<name> usage, and batch semantics
- link to User Form and task options docs for discovery

## Testing
- not run (docs change)
