### PR TITLE
Improve permissions explanation and add Mailchimp webhook support

### DIFF
--- a/core/tasks/permissions.md
+++ b/core/tasks/permissions.md
@@ -14,7 +14,7 @@ This can happen through:
 * Shopify data your task reads in Liquid
 * Shopify actions your task generates during [preview](previews/)
 
-Previews are valuable for more than permissions: they show users what the task will do, and they give developers a safe way to verify task behavior. They are still especially important when permission requirements depend on action arguments. For example, mutations like `tagsAdd` or `metafieldsSet` may require different scopes depending on the resource ID used, so realistic preview data still matters.
+A [preview](previews/) is Mechanic's safe, non-destructive rendering of your task. Previews are valuable for more than permissions: they show users what the task will do, and they give developers a safe way to verify task behavior. They are still especially important when permission requirements depend on action arguments. For example, mutations like `tagsAdd` or `metafieldsSet` may require different scopes depending on the resource ID used, so realistic preview data still matters.
 
 To get the best results:
 

--- a/platform/webhooks.md
+++ b/platform/webhooks.md
@@ -182,10 +182,11 @@ When configuring an integration with external apps and services, some require sp
 
 A webhook invocation signals its client selection via a path suffix. Given a webhook URL of `webhooks.mechanic.dev/0000..0000`, a client-specific endpoint for Ship24 (for example) would be available at `webhooks.mechanic.dev/0000..0000/ship24`.
 
-| Client | Webhook suffix | Behavior notes                                              |                                                                                                       |
-| ------ | -------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Asana  | asana          | Supports the `X-Hook-Secret` header for the handshake phase | [Docs](https://developers.asana.com/docs/webhooks)                                                    |
-| Ship24 | ship24         | Supports HEAD requests for webhook verification             | [Docs](https://documenter.getpostman.com/view/14877026/Tz5s4Gtu#3c5245aa-a14e-4995-ba3a-9045b92524e3) |
+| Client    | Webhook suffix | Behavior notes                                                                            |                                                                                                       |
+| --------- | -------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Asana     | asana          | Supports the `X-Hook-Secret` header for the handshake phase                               | [Docs](https://developers.asana.com/docs/webhooks)                                                    |
+| Mailchimp | mailchimp      | Supports GET and POST requests; returns 200 OK response instead of 204 No Content         | [Docs](https://mailchimp.com/developer/transactional/docs/webhooks/)                                  |
+| Ship24    | ship24         | Supports HEAD requests for webhook verification                                           | [Docs](https://documenter.getpostman.com/view/14877026/Tz5s4Gtu#3c5245aa-a14e-4995-ba3a-9045b92524e3) |
 
 ### Examples
 


### PR DESCRIPTION
## Summary

- Clarified preview definition in permissions documentation
- Added Mailchimp client-specific webhook endpoint documentation

## Changes

### Permissions Documentation (core/tasks/permissions.md)
Added clearer definition of preview as "safe, non-destructive rendering" at the beginning of the sentence to help readers understand what a preview is before explaining its value.

### Webhook Documentation (platform/webhooks.md)
Added Mailchimp to the client-specific endpoints table:
- **Endpoint suffix**: `/mailchimp`
- **Behavior**: Supports both GET and POST requests; returns 200 OK response instead of the standard 204 No Content
- Includes link to Mailchimp's webhook documentation
- Table formatting adjusted for proper alignment

## Context

Mailchimp webhooks require a 200 OK response for validation. Users should append `/mailchimp` to their webhook URL when configuring Mailchimp integrations.