### PR TITLE
Update Shopify event topics

### DIFF
--- a/platform/events/topics.md
+++ b/platform/events/topics.md
@@ -176,10 +176,12 @@ Need metaobject events, metafield filters, customized payloads, or custom routin
 * shopify/fulfillment\_orders/hold\_released
 * shopify/fulfillment\_orders/line\_items\_prepared\_for\_local\_delivery
 * shopify/fulfillment\_orders/line\_items\_prepared\_for\_pickup
+* shopify/fulfillment\_orders/manually\_reported\_progress\_stopped
 * shopify/fulfillment\_orders/merged
 * shopify/fulfillment\_orders/moved
 * shopify/fulfillment\_orders/order\_routing\_complete
 * shopify/fulfillment\_orders/placed\_on\_hold
+* shopify/fulfillment\_orders/progress\_reported
 * shopify/fulfillment\_orders/rescheduled
 * shopify/fulfillment\_orders/scheduled\_fulfillment\_order\_ready
 * shopify/fulfillment\_orders/split


### PR DESCRIPTION
## Summary

Linked maintenance issue: https://github.com/lightward/mechanic-api/issues/2252
Linked API PR: https://github.com/lightward/mechanic-api/pull/2256

- Adds the two generated Shopify fulfillment order event topics from the API docs output:
  - `shopify/fulfillment_orders/manually_reported_progress_stopped`
  - `shopify/fulfillment_orders/progress_reported`
- Preserves the existing `platform/events/topics.md` prose and escaped Markdown topic-list style.

## Verification

- Compared against `mechanic-api` `docs/shopify_event_topics.md` generated by `rake dev:update_all`.
