### PR TITLE
Document shop deprecations API and CLI

### DIFF
--- a/core/shopify/api-versions.md
+++ b/core/shopify/api-versions.md
@@ -26,13 +26,25 @@ Deprecations are ignored for the latest stable version of the Shopify API, i.e. 
 
 ### Identifying deprecations
 
-If support for a task's Shopify API version will be pulled soon, its deprecations will be shown above the main task list.
+If support for a task's Shopify API version will be pulled soon, its
+deprecations will be shown above the main task list in Mechanic.
 
 <figure><img src="../../.gitbook/assets/Screenshot 2023-09-02 at 5.05.59 PM.png" alt=""><figcaption></figcaption></figure>
 
 Deprecation details are available in the advanced task editor, in the Runtime tab.
 
 <figure><img src="../../.gitbook/assets/Screenshot 2023-09-02 at 5.09.01 PM.png" alt=""><figcaption></figcaption></figure>
+
+For local task development, use the [Mechanic CLI](../../platform/mechanic-cli.md)
+to list unresolved deprecations for the shop:
+
+```bash
+mechanic shop deprecations
+```
+
+Trusted scripts and monitoring tools can use
+[`GET /v1/shop/deprecations`](../../platform/mechanic-task-sync-api.md) with a
+Mechanic API token.
 
 ### Resolving deprecation warnings
 

--- a/core/tasks/shopify-api-version.md
+++ b/core/tasks/shopify-api-version.md
@@ -24,9 +24,15 @@ Shopify supports each version for 12 months (except for "unstable", which is alw
 
 Shopify may, at times, mark certain API features as deprecated. If a Mechanic account calls a deprecated API, Mechanic will display the deprecation notice in the app. Learn more about [Shopify API deprecations](../shopify/api-versions.md#deprecations).
 
+## Listing versions
+
+For local task development, `mechanic tasks list` shows each task's configured
+Shopify API version. The [task sync API](../../platform/mechanic-task-sync-api.md)
+also includes `shopify_api_version` in task sync envelopes, for trusted scripts
+and automation.
+
 ## Changing versions
 
 The selector for a task's Shopify API version is available in Advanced mode, below the task code area.
 
 ![](<../../.gitbook/assets/Screen Shot 2022-04-01 at 7.19.33 PM.png>)
-

--- a/platform/mechanic-cli.md
+++ b/platform/mechanic-cli.md
@@ -80,6 +80,8 @@ mechanic tasks pull <remote-task-id>
 ```
 
 This creates one local JSON file in `tasks/` and records the link to the matching task in Mechanic. Use this when you want to start with a specific task.
+The task list also shows each task's configured Shopify API version, which is
+useful when deciding which tasks may need an API version review.
 
 **Bootstrap the repo with every task in the shop:**
 
@@ -305,6 +307,29 @@ mechanic shop status --json
 
 This can be used with a service like Cronitor, UptimeRobot, Better Stack, or
 your own monitoring system. It is not required for publishing task changes.
+
+## Review Shopify API deprecations
+
+`shop deprecations` shows unresolved Shopify API deprecations reported by tasks
+in the configured shop:
+
+```bash
+mechanic shop deprecations
+```
+
+Use it when you want to find tasks that are still calling deprecated Shopify API
+surfaces. The output includes the task's configured Shopify API version, the API
+version seen in the deprecated request, the request path, and the last time
+Mechanic saw it.
+
+To focus on one linked task, pass the same task selector you would use for
+preview, diff, or publish:
+
+```bash
+mechanic shop deprecations order-tagger
+```
+
+Use `--json` when a script, agent, or dashboard needs structured output.
 
 ## Git and GitHub Actions
 

--- a/platform/mechanic-cli.md
+++ b/platform/mechanic-cli.md
@@ -121,7 +121,8 @@ Pick a task file from `tasks/`, or run:
 mechanic tasks list --verbose
 ```
 
-`--verbose` shows remote task IDs, linked local files, and sync details.
+`--verbose` shows remote task IDs, linked local files, configured Shopify API
+versions, and sync details.
 
 To start from scratch instead, create a new blank local task:
 

--- a/platform/mechanic-task-sync-api.md
+++ b/platform/mechanic-task-sync-api.md
@@ -70,7 +70,7 @@ direct HTTP only for trusted automation that can safely store a shop API token.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/v1/auth/verify` | Verify the API token; include an expected shop to receive shop and token context |
+| `GET` | `/v1/auth/verify` | Verify the API token; include an expected shop so mismatched tokens are rejected without revealing another shop |
 | `GET` | `/v1/shop/status` | Read current queue, backlog, and lag status |
 | `GET` | `/v1/shop/deprecations` | Read unresolved Shopify API deprecations reported by the shop's tasks |
 | `GET` | `/v1/tasks` | List tasks available to sync |

--- a/platform/mechanic-task-sync-api.md
+++ b/platform/mechanic-task-sync-api.md
@@ -64,12 +64,13 @@ For CI jobs, store the token as a secret named `MECHANIC_API_TOKEN` and expose i
 
 ## Endpoints
 
-This API is intentionally narrow. It covers task sync, task preview, and shop queue status for the authenticated shop.
+This API is intentionally narrow. It covers task sync, task preview, shop queue status, and Shopify API deprecation visibility for the authenticated shop.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/v1/auth/verify` | Verify the API token; include an expected shop to receive shop and token context |
 | `GET` | `/v1/shop/status` | Read current queue, backlog, and lag status |
+| `GET` | `/v1/shop/deprecations` | Read unresolved Shopify API deprecations reported by the shop's tasks |
 | `GET` | `/v1/tasks` | List tasks available to sync |
 | `GET` | `/v1/tasks/:id` | Read one task for sync |
 | `POST` | `/v1/tasks/preview` | Preview local task content without saving |
@@ -90,10 +91,30 @@ mechanic tasks preview order-tagger --json
 mechanic tasks publish order-tagger --dry-run
 mechanic tasks publish order-tagger
 mechanic shop status
+mechanic shop deprecations
 ```
 
 Use `mechanic shop status --json`, or `GET /v1/shop/status` directly, when you
 want an external monitor to alert on queue lag or waiting runs for the shop.
+
+Use `mechanic shop deprecations --json`, or `GET /v1/shop/deprecations`
+directly, when you want to inventory unresolved Shopify API deprecations for the
+shop. Add `task_id` to focus on one task:
+
+```bash
+curl "https://api.mechanic.dev/v1/shop/deprecations?task_id=<task-id>" \
+  -H "Authorization: Bearer $MECHANIC_API_TOKEN"
+```
+
+The response is capped and includes `total_count`, `limit`, and `truncated`.
+Deprecation entries include task identity, task Shopify API version, request API
+version, request method/path, occurrence count, and first/last occurrence times.
+They do not include request bodies, request headers, response headers, tokens, or
+other raw payload data.
+
+`GET /v1/tasks` and `GET /v1/tasks/:id` also include `shopify_api_version` in
+task sync envelopes, so scripts can see the configured API version without
+fetching or parsing the task JSON separately.
 
 ## Preview and publish behavior
 

--- a/platform/mechanic-task-sync-api.md
+++ b/platform/mechanic-task-sync-api.md
@@ -64,7 +64,9 @@ For CI jobs, store the token as a secret named `MECHANIC_API_TOKEN` and expose i
 
 ## Endpoints
 
-This API is intentionally narrow. It covers task sync, task preview, shop queue status, and Shopify API deprecation visibility for the authenticated shop.
+This API is intentionally narrow. It covers task sync, task preview, shop queue
+status, and Shopify API deprecation visibility for the authenticated shop. Use
+direct HTTP only for trusted automation that can safely store a shop API token.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
@@ -84,7 +86,7 @@ There is no `tasks new` API endpoint. `mechanic tasks new` is a local CLI comman
 `POST /v1/tasks` always creates a new task. It does not update an existing task by matching the task name or local slug. For direct HTTP creates, send an `Idempotency-Key` header with a UUID generated for the task you intend to create. Mechanic uses that UUID as the created task ID. Retrying with the same UUID returns the existing task instead of creating a duplicate, so use a different UUID for each intended task.
 {% endhint %}
 
-For most automation, prefer the CLI commands that wrap these endpoints:
+For most local task work, prefer the CLI commands that wrap these endpoints:
 
 ```bash
 mechanic tasks preview order-tagger --json
@@ -97,9 +99,10 @@ mechanic shop deprecations
 Use `mechanic shop status --json`, or `GET /v1/shop/status` directly, when you
 want an external monitor to alert on queue lag or waiting runs for the shop.
 
-Use `mechanic shop deprecations --json`, or `GET /v1/shop/deprecations`
-directly, when you want to inventory unresolved Shopify API deprecations for the
-shop. Add `task_id` to focus on one task:
+Use `mechanic shop deprecations --json` when a trusted script, agent, or
+dashboard needs structured deprecation data. Use `GET /v1/shop/deprecations`
+directly only when the automation needs to make HTTP requests itself. Add
+`task_id` to focus on one task:
 
 ```bash
 curl "https://api.mechanic.dev/v1/shop/deprecations?task_id=<task-id>" \


### PR DESCRIPTION
## Summary
- document the new `mechanic shop deprecations` command in the local task development guide
- add `GET /v1/shop/deprecations` to the task sync API reference
- note that task sync envelopes include `shopify_api_version`

## Test plan
- `git diff --check`