### PR TITLE
Document new Google Sheets operations

### DIFF
--- a/core/actions/integrations/google-sheets.md
+++ b/core/actions/integrations/google-sheets.md
@@ -103,7 +103,7 @@ Reads values from a range into the action's result, where a task subscribing to 
 Deletes a span of rows entirely — rows below shift up. Row numbers are 1-based and inclusive, matching what you see in the Sheets UI.
 
 {% hint style="warning" %}
-This operation is destructive, and is never retried automatically: if a deletion fails ambiguously after Google may have applied it, retrying could remove different rows. `sheet_name` is always required, so a reordering of tabs can never redirect a deletion to the wrong sheet.
+This operation is destructive, and is never retried automatically: if a deletion fails ambiguously after Google may have applied it, retrying could remove different rows. (Rate-limited rejections are the one exception — Google refuses those before applying anything, so they are safe to retry.) `sheet_name` is always required, so a reordering of tabs can never redirect a deletion to the wrong sheet.
 {% endhint %}
 
 #### Required Options

--- a/core/actions/integrations/google-sheets.md
+++ b/core/actions/integrations/google-sheets.md
@@ -1,6 +1,6 @@
 # Google Sheets
 
-The Google Sheets action allows you to interact with Google Sheets. It supports creating new spreadsheets, appending data to existing sheets, and exporting spreadsheets in various formats. Mechanic interacts with Google Sheets via the Google Sheets API, using OAuth2 for authentication.
+The Google Sheets action allows you to interact with Google Sheets. It supports creating spreadsheets (with one or many sheets), reading, appending, updating, and clearing data, deleting rows, managing sheets (tabs), and exporting spreadsheets in various formats. Mechanic interacts with Google Sheets via the Google Sheets API, using OAuth2 for authentication.
 
 {% hint style="info" %}
 Due to Google security restrictions, Mechanic can only access spreadsheets that were created through Mechanic itself. To work with Google Sheets:
@@ -14,13 +14,33 @@ See this great [example](https://tasks.mechanic.dev/demonstration-add-new-orders
 
 ## Options
 
-<table><thead><tr><th width="165">Option</th><th width="90">Type</th><th>Description</th></tr></thead><tbody><tr><td>account</td><td>string</td><td>Required: the Google account email address to authenticate with</td></tr><tr><td>operation</td><td>string</td><td>Required: the operation to perform. One of: "append_rows", "create_spreadsheet", "export_spreadsheet"</td></tr><tr><td>spreadsheet_id</td><td>string</td><td>Required: for append_rows and export_spreadsheet; the ID of the target spreadsheet</td></tr><tr><td>title</td><td>string</td><td>Required: for create_spreadsheet; the title for the new spreadsheet</td></tr><tr><td>rows</td><td>array</td><td>Required: for append_rows and optional for create_spreadsheet; array of arrays containing the data to write</td></tr><tr><td>sheet_name</td><td>string</td><td>Optional: for append_rows; defaults to "Sheet1"</td></tr><tr><td>file_type</td><td>string</td><td>Optional: for export_spreadsheet; the format to export. One of: "xlsx" (default), "csv", "pdf", "html", "ods", "tsv"</td></tr><tr><td>folder_path</td><td>string</td><td>Optional: for create_spreadsheet; the folder path where the spreadsheet should be created (e.g., "reports/2024/monthly")</td></tr><tr><td>retry_on_transient_errors</td><td>boolean</td><td>Optional: for append_rows; when set to true, allows Mechanic to automatically retry the operation on transient errors (e.g. timeouts, rate limits). Defaults to false.</td></tr></tbody></table>
+<table><thead><tr><th width="200">Option</th><th width="90">Type</th><th>Description</th></tr></thead><tbody><tr><td>account</td><td>string</td><td>Required: the Google account email address to authenticate with</td></tr><tr><td>operation</td><td>string</td><td>Required: the operation to perform. One of: "create_spreadsheet", "append_rows", "update_rows", "clear_values", "get_values", "delete_rows", "add_sheet", "rename_sheet", "delete_sheet", "export_spreadsheet"</td></tr><tr><td>spreadsheet_id</td><td>string</td><td>Required for every operation except create_spreadsheet; the ID of the target spreadsheet</td></tr><tr><td>title</td><td>string</td><td>For create_spreadsheet; the title for the new spreadsheet (defaults to "New Spreadsheet")</td></tr><tr><td>rows</td><td>array</td><td>Array of arrays containing the data to write. Required for append_rows and update_rows; optional for create_spreadsheet and add_sheet</td></tr><tr><td>sheets</td><td>array</td><td>For create_spreadsheet; an array of <code>{"name": ..., "rows": [...]}</code> objects to create a spreadsheet with multiple named sheets. Mutually exclusive with "rows"</td></tr><tr><td>sheet_name</td><td>string</td><td>The name of the sheet (tab) to target. Required for add_sheet, delete_rows, rename_sheet, and delete_sheet. Optional for append_rows, update_rows, clear_values, and get_values — when omitted where allowed, the first sheet is used (whatever its name; Mechanic never assumes "Sheet1")</td></tr><tr><td>new_sheet_name</td><td>string</td><td>Required for rename_sheet; the new name for the sheet</td></tr><tr><td>sheet_range</td><td>string</td><td>An A1-notation range (e.g. "Orders!A2:C10"). Used by append_rows, update_rows, clear_values, and get_values. A range without a sheet qualifier combines with sheet_name when one is given</td></tr><tr><td>start_row / end_row</td><td>number</td><td>For delete_rows; 1-based, inclusive row numbers. end_row defaults to start_row (a single row)</td></tr><tr><td>value_input_option</td><td>string</td><td>For operations that write values: "raw" (default — values are stored exactly as given) or "user_entered" (values are parsed as if typed into the Sheets UI: dates become dates, numbers become numbers, and strings starting with "=" become formulas)</td></tr><tr><td>value_render_option</td><td>string</td><td>For get_values: "formatted_value" (default), "unformatted_value", or "formula"</td></tr><tr><td>file_type</td><td>string</td><td>For export_spreadsheet; one of: "xlsx" (default), "csv", "pdf", "html", "ods", "tsv"</td></tr><tr><td>folder_path</td><td>string</td><td>For create_spreadsheet; the folder path where the spreadsheet should be created (e.g., "reports/2024/monthly")</td></tr><tr><td>retry_on_transient_errors</td><td>boolean</td><td>For append_rows; when true, allows Mechanic to retry the append on ambiguous transient errors (e.g. timeouts). Defaults to false</td></tr></tbody></table>
+
+{% hint style="warning" %}
+**Only use `"value_input_option": "user_entered"` with data you trust.** Under `user_entered`, any cell value beginning with `=` is executed as a live formula in the spreadsheet. Customer-supplied values (order notes, names, line item properties) should be written with the default `"raw"` mode.
+{% endhint %}
 
 ## Operations
 
+### create\_spreadsheet
+
+Creates a new spreadsheet — with a single sheet (optionally populated via `rows`), or with multiple named sheets via `sheets`.
+
+#### Required Options
+
+* account
+
+#### Optional Options
+
+* title (defaults to "New Spreadsheet")
+* folder\_path (path where spreadsheet should be created)
+* rows (initial data for the default sheet)
+* sheets (an array of `{"name": ..., "rows": [...]}` objects; mutually exclusive with rows)
+* value\_input\_option
+
 ### append\_rows
 
-Adds new rows to an existing spreadsheet.
+Adds new rows to the end of a sheet's existing data.
 
 #### Required Options
 
@@ -30,26 +50,108 @@ Adds new rows to an existing spreadsheet.
 
 #### Optional Options
 
-* sheet\_name (defaults to "Sheet1")
+* sheet\_name (defaults to the spreadsheet's first sheet)
+* sheet\_range (an explicit A1 range to append within)
+* value\_input\_option
 * retry\_on\_transient\_errors (defaults to false)
 
 {% hint style="warning" %}
-The `retry_on_transient_errors` option is opt-in because some transient failures are ambiguous — for example, a timeout or connection reset may occur after Google has already accepted the write but before Mechanic receives confirmation. Retrying in that case can result in duplicate rows. Other transient errors like rate limits (`429`) are safe to retry since the request was rejected, but because this option enables retries for all transient errors as a group, callers should be prepared for occasional duplicates.
+The `retry_on_transient_errors` option is opt-in because some transient failures are ambiguous — for example, a timeout or connection reset may occur after Google has already accepted the write but before Mechanic receives confirmation. Retrying in that case can result in duplicate rows. Rate-limited requests (HTTP 429) are rejected before any data is written, so Mechanic always retries those automatically; this option only governs the ambiguous cases.
 {% endhint %}
 
-### create\_spreadsheet
+### update\_rows
 
-Creates a new spreadsheet, optionally with initial data.
+Writes rows at a specific range, overwriting whatever is there. Provide `sheet_range` (e.g. `"Orders!A5:C5"`), or `sheet_name` alone to write starting at the sheet's A1. Updates to a fixed range are idempotent, so Mechanic retries transient failures automatically.
 
 #### Required Options
 
 * account
-* title
+* spreadsheet\_id
+* rows
+* sheet\_range or sheet\_name
 
 #### Optional Options
 
-* folder\_path (path where spreadsheet should be created)
-* rows (initial data to populate the spreadsheet)
+* value\_input\_option
+
+### clear\_values
+
+Clears the values in a range (formatting is left intact). Provide `sheet_range`, or `sheet_name` alone to clear the entire sheet.
+
+#### Required Options
+
+* account
+* spreadsheet\_id
+* sheet\_range or sheet\_name
+
+### get\_values
+
+Reads values from a range into the action's result, where a task subscribing to `mechanic/actions/perform` can use them — for example, to find which row holds a particular order before updating or deleting it. When neither `sheet_range` nor `sheet_name` is given, the entire first sheet is read. Results are capped at 20MB; narrow the range for very large sheets.
+
+#### Required Options
+
+* account
+* spreadsheet\_id
+
+#### Optional Options
+
+* sheet\_range or sheet\_name
+* value\_render\_option ("formatted\_value" by default; "unformatted\_value" returns raw numbers; "formula" returns cell formulas)
+
+### delete\_rows
+
+Deletes a span of rows entirely — rows below shift up. Row numbers are 1-based and inclusive, matching what you see in the Sheets UI.
+
+{% hint style="warning" %}
+This operation is destructive, and is never retried automatically: if a deletion fails ambiguously after Google may have applied it, retrying could remove different rows. `sheet_name` is always required, so a reordering of tabs can never redirect a deletion to the wrong sheet.
+{% endhint %}
+
+#### Required Options
+
+* account
+* spreadsheet\_id
+* sheet\_name
+* start\_row
+
+#### Optional Options
+
+* end\_row (defaults to start\_row, deleting a single row)
+
+### add\_sheet
+
+Adds a new sheet (tab) to an existing spreadsheet, optionally populated with initial rows.
+
+#### Required Options
+
+* account
+* spreadsheet\_id
+* sheet\_name
+
+#### Optional Options
+
+* rows
+* value\_input\_option
+
+### rename\_sheet
+
+Renames a sheet (tab), located by its current name.
+
+#### Required Options
+
+* account
+* spreadsheet\_id
+* sheet\_name (the current name)
+* new\_sheet\_name
+
+### delete\_sheet
+
+Deletes a sheet (tab) by name. A spreadsheet's last remaining sheet cannot be deleted. Like delete\_rows, this operation is never retried automatically.
+
+#### Required Options
+
+* account
+* spreadsheet\_id
+* sheet\_name
 
 ### export\_spreadsheet
 
@@ -69,6 +171,12 @@ Exports a spreadsheet in various formats.
   * html
   * ods
   * tsv
+
+## Sheet names and ranges
+
+* Sheet names are matched exactly, and Mechanic looks up the actual sheet names from the spreadsheet — language-specific default names ("Sheet1", "Foglio1", "Hoja1", …) are handled automatically.
+* When Mechanic composes a range from a `sheet_name`, names containing spaces or special characters are quoted automatically — pass the plain name (e.g. `"Order Data"`).
+* A `sheet_range` without a sheet qualifier (e.g. `"A5:C10"`) combines with `sheet_name` when one is given. A qualified `sheet_range` (e.g. `"Orders!A5:C10"`) that conflicts with `sheet_name` is rejected as an error.
 
 ## Authentication
 
@@ -136,6 +244,90 @@ archives/exports/sheets   # Three levels deep
 {% endaction %}
 ```
 
+### Create a Spreadsheet with Multiple Sheets
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "create_spreadsheet",
+    "title": "Sales Report",
+    "sheets": [
+      {
+        "name": "Orders",
+        "rows": [["Order ID", "Total"]]
+      },
+      {
+        "name": "Refunds",
+        "rows": [["Refund ID", "Amount"]]
+      }
+    ]
+  }
+{% endaction %}
+```
+
+### Add a Sheet to an Existing Spreadsheet
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "add_sheet",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Q3",
+    "rows": [["Date", "Revenue"]]
+  }
+{% endaction %}
+```
+
+### Update Rows at a Specific Range
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "update_rows",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_range": "Orders!A5:C5",
+    "rows": [
+      ["1001", "John Doe", "129.99"]
+    ]
+  }
+{% endaction %}
+```
+
+### Parse Dates and Formulas with user\_entered
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "append_rows",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Totals",
+    "value_input_option": "user_entered",
+    "rows": [
+      ["2026-06-09", 49.99, "=SUM(B:B)"]
+    ]
+  }
+{% endaction %}
+```
+
+### Delete Rows
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "delete_rows",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Orders",
+    "start_row": 5,
+    "end_row": 7
+  }
+{% endaction %}
+```
+
 ### Export Google Sheet
 
 ```liquid
@@ -167,49 +359,9 @@ archives/exports/sheets   # Three levels deep
 {% endaction %}
 ```
 
-### Dynamic Data Example
+### Read Data from a Google Sheet
 
-```liquid
-{% assign order_rows = array %}
-{% assign header_row = array %}
-{% assign header_row["Order", "Customer", "Total"] %}
-{% assign order_rows[header_row] %}
-
-{% for order in shop.orders %}
-  {% assign order_row = array %}
-  {% assign order_row[order.name, order.customer.name, order.total_price] %}
-  {% assign order_rows[order_row] %}
-{% endfor %}
-
-{% action "google_sheets" %}
-  {
-    "account": {{ options.google_account | json }},
-    "operation": "append_rows",
-    "spreadsheet_id": {{ options.spreadsheet_id | json }},
-    "rows": {{ order_rows | json }}
-  }
-{% endaction %}
-```
-
-### Create Google Sheet in a Folder
-
-```liquid
-{% action "google_sheets" %}
-  {
-    "account": "user@example.com",
-    "operation": "create_spreadsheet",
-    "folder_path": "reports/2024/monthly",
-    "title": "March Sales",
-    "rows": [
-      ["Date", "Revenue", "Units"],
-      ["2024-03-01", "5000", "50"],
-      ["2024-03-02", "6000", "60"]
-    ]
-  }
-{% endaction %}
-```
-
-### Read Data From Google Sheet
+Use `get_values` together with a `mechanic/actions/perform` subscription to read data back into a task — for example, as the first pass of a find-then-update workflow.
 
 {% code title="Task subscriptions" %}
 
@@ -223,30 +375,45 @@ mechanic/actions/perform
 {% code title="Task code" %}
 
 ```liquid
-
-
-
-
-  
-
-
-
-
-
-
-
-  
-
-
-    {% assign sheet_data = action.run.result.data_base64 | 
-    base64_decode | parse_csv: headers: true %}
-      {% action "echo" sheet_data %}
-  
-
-
+{% if event.topic == "mechanic/user/trigger" %}
+  {% action "google_sheets" %}
+    {
+      "account": "user@example.com",
+      "operation": "get_values",
+      "spreadsheet_id": "1234567890abcdef",
+      "sheet_range": "Orders!A1:C100"
+    }
+  {% endaction %}
+{% elsif event.topic == "mechanic/actions/perform" %}
+  {% assign sheet_rows = action.run.result.values %}
+  {% action "echo" sheet_rows %}
+{% endif %}
 ```
 
 {% endcode %}
+
+### Dynamic Data Example
+
+```liquid
+{% assign order_rows = array %}
+
+{% for order in shop.orders %}
+  {% assign order_row = array %}
+  {% assign order_row[0] = order.name %}
+  {% assign order_row[1] = order.customer.name %}
+  {% assign order_row[2] = order.total_price %}
+  {% assign order_rows[order_rows.size] = order_row %}
+{% endfor %}
+
+{% action "google_sheets" %}
+  {
+    "account": {{ options.google_account | json }},
+    "operation": "append_rows",
+    "spreadsheet_id": {{ options.spreadsheet_id | json }},
+    "rows": {{ order_rows | json }}
+  }
+{% endaction %}
+```
 
 ## Action Responses
 
@@ -264,25 +431,15 @@ The action returns different responses based on the operation performed:
 }
 ```
 
-### Example:
-
-```json
-{
-  "spreadsheet_id": "1234567890abcdef",
-  "updated_range": "Sheet1!A1:C3",
-  "updated_rows": 3,
-  "updated_columns": 3,
-  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
-}
-```
-
-#### create\_spreadsheet Response
+### create\_spreadsheet Response
 
 ```typescript
 {
   "spreadsheet_id": string,
   "spreadsheet_url": string,
-  "title": string
+  "title": string,
+  "folder_path": string | null,
+  "sheets": [{ "name": string, "sheet_id": number }] // present when created with "sheets"
 }
 ```
 
@@ -292,33 +449,100 @@ Example:
 {
   "spreadsheet_id": "1234567890abcdef",
   "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef",
-  "title": "Monthly Sales Report"
+  "title": "Sales Report",
+  "folder_path": "reports/2026",
+  "sheets": [
+    { "name": "Orders", "sheet_id": 0 },
+    { "name": "Refunds", "sheet_id": 1234 }
+  ]
 }
 ```
 
-#### create\_spreadsheet Response with Folder
+### add\_sheet Response
 
 ```typescript
 {
   "spreadsheet_id": string,
+  "sheet_id": number,
+  "sheet_name": string,
   "spreadsheet_url": string,
-  "title": string,
-  "folder_path": string
+  "updated_rows": number,    // present when rows were written
+  "updated_columns": number  // present when rows were written
 }
 ```
 
-#### Example:
+### update\_rows Response
 
-```json
+```typescript
 {
-  "spreadsheet_id": "1234567890abcdef",
-  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef",
-  "title": "March Sales",
-  "folder_path": "reports/2024/monthly"
+  "spreadsheet_id": string,
+  "updated_range": string,
+  "updated_rows": number,
+  "updated_columns": number,
+  "updated_cells": number,
+  "spreadsheet_url": string
 }
 ```
 
-#### export\_spreadsheet Response
+### clear\_values Response
+
+```typescript
+{
+  "spreadsheet_id": string,
+  "cleared_range": string,
+  "spreadsheet_url": string
+}
+```
+
+### get\_values Response
+
+```typescript
+{
+  "spreadsheet_id": string,
+  "range": string,
+  "values": string[][],
+  "row_count": number,
+  "spreadsheet_url": string
+}
+```
+
+### delete\_rows Response
+
+```typescript
+{
+  "spreadsheet_id": string,
+  "sheet_name": string,
+  "start_row": number,
+  "end_row": number,
+  "deleted_rows": number,
+  "spreadsheet_url": string
+}
+```
+
+### rename\_sheet Response
+
+```typescript
+{
+  "spreadsheet_id": string,
+  "sheet_id": number,
+  "previous_sheet_name": string,
+  "sheet_name": string,
+  "spreadsheet_url": string
+}
+```
+
+### delete\_sheet Response
+
+```typescript
+{
+  "spreadsheet_id": string,
+  "sheet_id": number,
+  "sheet_name": string,
+  "spreadsheet_url": string
+}
+```
+
+### export\_spreadsheet Response
 
 ```typescript
 {

--- a/platform/integrations/google-drive-and-google-sheets.md
+++ b/platform/integrations/google-drive-and-google-sheets.md
@@ -49,7 +49,7 @@ See in-depth documentation of the Google Drive action [here](../../core/actions/
 
 ### Google Sheets Integration
 
-The Google Sheets action enables focused interaction with spreadsheets, including sheet creation, appending data, and data exports. \
+The Google Sheets action enables focused interaction with spreadsheets, including creating spreadsheets with one or many sheets, reading and writing data, deleting rows, managing sheets (tabs), and exporting. \
 
 
 See in-depth documentation of the Google Sheets action [here](../../core/actions/integrations/google-sheets.md).
@@ -73,8 +73,15 @@ See in-depth documentation of the Google Sheets action [here](../../core/actions
 
 #### Supported Operations
 
-* `create_spreadsheet`: Create new spreadsheets
+* `create_spreadsheet`: Create new spreadsheets, with one or many named sheets
 * `append_rows`: Add data to existing spreadsheets
+* `update_rows`: Overwrite data at a specific range
+* `clear_values`: Clear values from a range or a whole sheet
+* `get_values`: Read values from a spreadsheet into the action result
+* `delete_rows`: Delete a span of rows from a sheet
+* `add_sheet`: Add a sheet (tab) to an existing spreadsheet
+* `rename_sheet`: Rename a sheet (tab)
+* `delete_sheet`: Delete a sheet (tab)
 * `export_spreadsheet`: Export spreadsheets in various formats
 
 ### File Type Support


### PR DESCRIPTION
## Summary

Documentation for the expanded `google_sheets` action (lightward/mechanic-api#2266 and lightward/mechanic-ui#2033): the action grows from 3 to 10 operations.

**[core/actions/integrations/google-sheets.md](https://github.com/lightward/mechanic-docs/blob/claude/google-sheets-operations-docs/core/actions/integrations/google-sheets.md)** — rewritten:
- Options table covers the full option set (`sheets`, `sheet_range`, `new_sheet_name`, `start_row`/`end_row`, `value_input_option`, `value_render_option`)
- Operation sections for `add_sheet`, `update_rows`, `clear_values`, `get_values`, `delete_rows`, `rename_sheet`, `delete_sheet`, and multi-sheet `create_spreadsheet`, each with retry-behavior notes (destructive operations are never auto-retried)
- A prominent warning that `user_entered` executes `=`-prefixed values as live formulas — trusted data only
- "Sheet names and ranges" section covering automatic quoting, first-sheet auto-detection (never assumes "Sheet1"), and range/name conflict rules
- Response shapes for every operation
- New examples: multi-sheet create, add_sheet, update_rows, user_entered, delete_rows, and a working `get_values` + `mechanic/actions/perform` read-back pattern

Also fixes pre-existing page issues: the options table claimed `sheet_name` "defaults to Sheet1" (auto-detection shipped with the locale fix); the retry hint's rate-limit wording no longer matched behavior; the "Read Data From Google Sheet" example was an empty mangled code block; and the "Dynamic Data Example" used invalid array assignment syntax.

**[platform/integrations/google-drive-and-google-sheets.md](https://github.com/lightward/mechanic-docs/blob/claude/google-sheets-operations-docs/platform/integrations/google-drive-and-google-sheets.md)** — capability sentence and supported-operations list updated to the full set.

Should merge alongside (or after) the API/UI PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)