### PR TITLE
Restructure the Google Sheets action page for readability

### DIFF
--- a/core/actions/integrations/google-sheets.md
+++ b/core/actions/integrations/google-sheets.md
@@ -1,215 +1,130 @@
 # Google Sheets
 
-The Google Sheets action allows you to interact with Google Sheets. It supports creating spreadsheets (with one or many sheets), reading, appending, updating, and clearing data, deleting rows, managing sheets (tabs), and exporting spreadsheets in various formats. Mechanic interacts with Google Sheets via the Google Sheets API, using OAuth2 for authentication.
+The Google Sheets action lets tasks create, read, write, and manage Google Sheets spreadsheets. Mechanic interacts with Google Sheets via the Google Sheets API, using OAuth2 for authentication — see [Authentication](#authentication).
 
 {% hint style="info" %}
-Due to Google security restrictions, Mechanic can only access spreadsheets that were created through Mechanic itself. To work with Google Sheets:
+Due to Google security restrictions, Mechanic can only access spreadsheets that were created through Mechanic itself — no other spreadsheets in your drive. To work with Google Sheets:
 
 * First create a spreadsheet using the `"create_spreadsheet"` operation
 * Store the returned spreadsheet ID for later use
-* Then use operations like `"append_rows"` on this spreadsheet
+* Then use the other operations on this spreadsheet
 
 See this great [example](https://tasks.mechanic.dev/demonstration-add-new-orders-to-google-sheet) in the task library.
 {% endhint %}
 
-## Options
-
-<table><thead><tr><th width="200">Option</th><th width="90">Type</th><th>Description</th></tr></thead><tbody><tr><td>account</td><td>string</td><td>Required: the Google account email address to authenticate with</td></tr><tr><td>operation</td><td>string</td><td>Required: the operation to perform. One of: "create_spreadsheet", "append_rows", "update_rows", "clear_values", "get_values", "delete_rows", "add_sheet", "rename_sheet", "delete_sheet", "export_spreadsheet"</td></tr><tr><td>spreadsheet_id</td><td>string</td><td>Required for every operation except create_spreadsheet; the ID of the target spreadsheet</td></tr><tr><td>title</td><td>string</td><td>For create_spreadsheet; the title for the new spreadsheet (defaults to "New Spreadsheet")</td></tr><tr><td>rows</td><td>array</td><td>Array of arrays containing the data to write. Required for append_rows and update_rows; optional for create_spreadsheet and add_sheet</td></tr><tr><td>sheets</td><td>array</td><td>For create_spreadsheet; an array of <code>{"name": ..., "rows": [...]}</code> objects to create a spreadsheet with multiple named sheets. Mutually exclusive with "rows"</td></tr><tr><td>sheet_name</td><td>string</td><td>The name of the sheet (tab) to target. Required for add_sheet, delete_rows, rename_sheet, and delete_sheet. Optional for append_rows, update_rows, clear_values, and get_values — when omitted where allowed, the first sheet is used (whatever its name; Mechanic never assumes "Sheet1")</td></tr><tr><td>new_sheet_name</td><td>string</td><td>Required for rename_sheet; the new name for the sheet</td></tr><tr><td>sheet_range</td><td>string</td><td>An A1-notation range (e.g. "Orders!A2:C10"). Used by append_rows, update_rows, clear_values, and get_values. A range without a sheet qualifier combines with sheet_name when one is given</td></tr><tr><td>start_row / end_row</td><td>number</td><td>For delete_rows; 1-based, inclusive row numbers. end_row defaults to start_row (a single row)</td></tr><tr><td>value_input_option</td><td>string</td><td>For operations that write values: "raw" (default — values are stored exactly as given) or "user_entered" (values are parsed as if typed into the Sheets UI: dates become dates, numbers become numbers, and strings starting with "=" become formulas)</td></tr><tr><td>value_render_option</td><td>string</td><td>For get_values: "formatted_value" (default), "unformatted_value", or "formula"</td></tr><tr><td>file_type</td><td>string</td><td>For export_spreadsheet; one of: "xlsx" (default), "csv", "pdf", "html", "ods", "tsv"</td></tr><tr><td>folder_path</td><td>string</td><td>For create_spreadsheet; the folder path where the spreadsheet should be created (e.g., "reports/2024/monthly")</td></tr><tr><td>retry_on_transient_errors</td><td>boolean</td><td>For append_rows; when true, allows Mechanic to retry the append on ambiguous transient errors (e.g. timeouts). Defaults to false</td></tr></tbody></table>
-
-{% hint style="warning" %}
-**Only use `"value_input_option": "user_entered"` with data you trust.** Under `user_entered`, any cell value beginning with `=` is executed as a live formula in the spreadsheet. Customer-supplied values (order notes, names, line item properties) should be written with the default `"raw"` mode.
-{% endhint %}
-
 ## Operations
 
-### create\_spreadsheet
+| Operation                                       | Use it to                                                  |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| [`create_spreadsheet`](#create_spreadsheet)     | Create a spreadsheet, with one or many named sheets        |
+| [`append_rows`](#append_rows)                   | Add rows to the end of a sheet's data                      |
+| [`update_rows`](#update_rows)                   | Overwrite rows at a specific range                         |
+| [`clear_values`](#clear_values)                 | Clear a range, or a whole sheet                            |
+| [`get_values`](#get_values)                     | Read values into the action result                         |
+| [`delete_rows`](#delete_rows)                   | Delete a span of rows (rows below shift up)                |
+| [`add_sheet`](#add_sheet)                       | Add a sheet (tab) to an existing spreadsheet               |
+| [`rename_sheet`](#rename_sheet)                 | Rename a sheet (tab)                                       |
+| [`delete_sheet`](#delete_sheet)                 | Delete a sheet (tab)                                       |
+| [`export_spreadsheet`](#export_spreadsheet)     | Export the spreadsheet as XLSX, CSV, PDF, HTML, ODS, or TSV |
+
+Every operation requires `"account"` (the email address of a [connected Google account](#authentication)), and every operation except `create_spreadsheet` requires `"spreadsheet_id"`. Each operation's remaining options are listed in its section below.
+
+## Targeting sheets and ranges
+
+These conventions apply across the operations:
+
+* **`sheet_name`** targets a sheet (tab) by its exact name. Where it's optional (`append_rows`, `update_rows`, `clear_values`, `get_values`), omitting it targets the spreadsheet's **first sheet** — Mechanic looks up the actual name, so language-specific defaults ("Sheet1", "Foglio1", "Hoja1", …) are handled automatically. Pass plain names (e.g. `"Order Data"`); Mechanic quotes them for A1 notation as needed.
+* **`sheet_range`** is an A1-notation range (e.g. `"Orders!A2:C10"`). A range without a sheet qualifier (e.g. `"A2:C10"`) combines with `sheet_name` when one is given. A qualified range that conflicts with `sheet_name` is rejected as an error.
+
+## Writing values
+
+Operations that write data (`create_spreadsheet`, `append_rows`, `update_rows`, `add_sheet`) accept `"value_input_option"`:
+
+* `"raw"` (default) — values are stored exactly as given
+* `"user_entered"` — values are parsed as if typed into the Sheets UI: dates become dates, numbers become numbers, and strings starting with `=` become formulas
+
+{% hint style="warning" %}
+**Only use `"user_entered"` with data you trust.** Under `user_entered`, any cell value beginning with `=` executes as a live formula in the spreadsheet. Customer-supplied values (order notes, names, line item properties) should be written with the default `"raw"` mode.
+{% endhint %}
+
+## Retries
+
+* **Reads and idempotent writes** (`get_values`, `update_rows`, `clear_values`, `rename_sheet`) are retried automatically on transient errors.
+* **Ambiguous writes** (`append_rows`, `create_spreadsheet`, `add_sheet`, `delete_rows`, `delete_sheet`) are not retried automatically, because a timeout may occur after Google already applied the change — retrying could duplicate rows or delete the wrong ones. `append_rows` supports opting in via `"retry_on_transient_errors": true`.
+* **Rate limits** (HTTP 429) are always retried automatically, for every operation: Google rejects rate-limited requests before applying anything, so they're safe.
+
+***
+
+## create\_spreadsheet
 
 Creates a new spreadsheet — with a single sheet (optionally populated via `rows`), or with multiple named sheets via `sheets`.
 
-#### Required Options
-
-* account
-
-#### Optional Options
-
-* title (defaults to "New Spreadsheet")
-* folder\_path (path where spreadsheet should be created)
-* rows (initial data for the default sheet)
-* sheets (an array of `{"name": ..., "rows": [...]}` objects; mutually exclusive with rows)
-* value\_input\_option
-
-### append\_rows
-
-Adds new rows to the end of a sheet's existing data.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* rows
-
-#### Optional Options
-
-* sheet\_name (defaults to the spreadsheet's first sheet)
-* sheet\_range (an explicit A1 range to append within)
-* value\_input\_option
-* retry\_on\_transient\_errors (defaults to false)
-
-{% hint style="warning" %}
-The `retry_on_transient_errors` option is opt-in because some transient failures are ambiguous — for example, a timeout or connection reset may occur after Google has already accepted the write but before Mechanic receives confirmation. Retrying in that case can result in duplicate rows. Rate-limited requests (HTTP 429) are rejected before any data is written, so Mechanic always retries those automatically; this option only governs the ambiguous cases.
-{% endhint %}
-
-### update\_rows
-
-Writes rows at a specific range, overwriting whatever is there. Provide `sheet_range` (e.g. `"Orders!A5:C5"`), or `sheet_name` alone to write starting at the sheet's A1. Updates to a fixed range are idempotent, so Mechanic retries transient failures automatically.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* rows
-* sheet\_range or sheet\_name
-
-#### Optional Options
-
-* value\_input\_option
-
-### clear\_values
-
-Clears the values in a range (formatting is left intact). Provide `sheet_range`, or `sheet_name` alone to clear the entire sheet.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* sheet\_range or sheet\_name
-
-### get\_values
-
-Reads values from a range into the action's result, where a task subscribing to `mechanic/actions/perform` can use them — for example, to find which row holds a particular order before updating or deleting it. When neither `sheet_range` nor `sheet_name` is given, the entire first sheet is read. Results are capped at 20MB; narrow the range for very large sheets.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-
-#### Optional Options
-
-* sheet\_range or sheet\_name
-* value\_render\_option ("formatted\_value" by default; "unformatted\_value" returns raw numbers; "formula" returns cell formulas)
-
-### delete\_rows
-
-Deletes a span of rows entirely — rows below shift up. Row numbers are 1-based and inclusive, matching what you see in the Sheets UI.
-
-{% hint style="warning" %}
-This operation is destructive, and is never retried automatically: if a deletion fails ambiguously after Google may have applied it, retrying could remove different rows. (Rate-limited rejections are the one exception — Google refuses those before applying anything, so they are safe to retry.) `sheet_name` is always required, so a reordering of tabs can never redirect a deletion to the wrong sheet.
-{% endhint %}
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* sheet\_name
-* start\_row
-
-#### Optional Options
-
-* end\_row (defaults to start\_row, deleting a single row)
-
-### add\_sheet
-
-Adds a new sheet (tab) to an existing spreadsheet, optionally populated with initial rows.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* sheet\_name
-
-#### Optional Options
-
-* rows
-* value\_input\_option
-
-### rename\_sheet
-
-Renames a sheet (tab), located by its current name.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* sheet\_name (the current name)
-* new\_sheet\_name
-
-### delete\_sheet
-
-Deletes a sheet (tab) by name. A spreadsheet's last remaining sheet cannot be deleted. Like delete\_rows, this operation is never retried automatically.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-* sheet\_name
-
-### export\_spreadsheet
-
-Exports a spreadsheet in various formats.
-
-#### Required Options
-
-* account
-* spreadsheet\_id
-
-#### Optional Options
-
-* file\_type
-  * xlsx (default)
-  * csv
-  * pdf
-  * html
-  * ods
-  * tsv
-
-## Sheet names and ranges
-
-* Sheet names are matched exactly, and Mechanic looks up the actual sheet names from the spreadsheet — language-specific default names ("Sheet1", "Foglio1", "Hoja1", …) are handled automatically.
-* When Mechanic composes a range from a `sheet_name`, names containing spaces or special characters are quoted automatically — pass the plain name (e.g. `"Order Data"`).
-* A `sheet_range` without a sheet qualifier (e.g. `"A5:C10"`) combines with `sheet_name` when one is given. A qualified `sheet_range` (e.g. `"Orders!A5:C10"`) that conflicts with `sheet_name` is rejected as an error.
-
-## Authentication
-
-This action requires connecting a Google account with the appropriate permissions. To connect an account:
-
-1. Go to **Settings → Authentication**
-2. Select **Google** in the provider list
-3. Follow the Google account connection flow
-
-## File Access
-
-The action can only access spreadsheets it creates, no other spreadsheets in your drive.
-
-## Folder Support
-
-When creating spreadsheets, you can specify a folder path to organize your files:
-
-* Use forward slashes to separate folder names (e.g., "reports/2024/monthly")
-* Folders will be created if they don't exist
-* Can only access folders created by this integration
-* Invalid characters not allowed: `< > : " / \ | ? *`
-
-### Folder Path Examples
-
-```
-reports/monthly           # Two levels deep
-data/2024/q1/sales       # Four levels deep
-archives/exports/sheets   # Three levels deep
+| Option                 | Required | Notes                                                                                       |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `title`                | no       | Defaults to "New Spreadsheet"                                                                |
+| `rows`                 | no       | Array of arrays; initial data for the default sheet. Mutually exclusive with `sheets`        |
+| `sheets`               | no       | Array of `{"name": ..., "rows": [...]}` objects, to create multiple named sheets             |
+| `folder_path`          | no       | Folder to create the spreadsheet in — see [Folders](#folders)                                |
+| `value_input_option`   | no       | See [Writing values](#writing-values)                                                        |
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "create_spreadsheet",
+    "title": "Monthly Sales Report",
+    "rows": [
+      ["Month", "Revenue", "Expenses", "Profit"],
+      ["January", "5000", "3000", "2000"]
+    ]
+  }
+{% endaction %}
 ```
 
-## Examples
+With multiple sheets:
 
-### Append Rows to Existing Google Sheet
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "create_spreadsheet",
+    "title": "Sales Report",
+    "sheets": [
+      { "name": "Orders", "rows": [["Order ID", "Total"]] },
+      { "name": "Refunds", "rows": [["Refund ID", "Amount"]] }
+    ]
+  }
+{% endaction %}
+```
+
+Response:
+
+```json
+{
+  "spreadsheet_id": "1234567890abcdef",
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef",
+  "title": "Sales Report",
+  "folder_path": "reports/2026",
+  "sheets": [
+    { "name": "Orders", "sheet_id": 0 },
+    { "name": "Refunds", "sheet_id": 1234 }
+  ]
+}
+```
+
+(`folder_path` is null when not given; `sheets` is present when created with `sheets`.)
+
+## append\_rows
+
+Adds new rows after a sheet's existing data.
+
+| Option                       | Required | Notes                                                                      |
+| ---------------------------- | -------- | --------------------------------------------------------------------------- |
+| `rows`                       | yes      | Array of arrays                                                              |
+| `sheet_name`                 | no       | Defaults to the first sheet — see [Targeting](#targeting-sheets-and-ranges)  |
+| `sheet_range`                | no       | An explicit A1 range to append within                                        |
+| `value_input_option`         | no       | See [Writing values](#writing-values)                                        |
+| `retry_on_transient_errors`  | no       | Defaults to false — see [Retries](#retries)                                  |
 
 ```liquid
 {% action "google_sheets" %}
@@ -220,67 +135,57 @@ archives/exports/sheets   # Three levels deep
     "sheet_name": "Orders",
     "rows": [
       ["Order ID", "Customer", "Total"],
-      ["1001", "John Doe", "99.99"],
-      ["1002", "Jane Smith", "149.99"]
+      ["1001", "John Doe", "99.99"]
     ]
   }
 {% endaction %}
 ```
 
-### Create New Google Sheet
+Building rows dynamically:
 
 ```liquid
+{% assign order_rows = array %}
+
+{% for order in shop.orders %}
+  {% assign order_row = array %}
+  {% assign order_row[0] = order.name %}
+  {% assign order_row[1] = order.customer.name %}
+  {% assign order_row[2] = order.total_price %}
+  {% assign order_rows[order_rows.size] = order_row %}
+{% endfor %}
+
 {% action "google_sheets" %}
   {
-    "account": "user@example.com",
-    "operation": "create_spreadsheet",
-    "title": "Monthly Sales Report",
-    "rows": [
-      ["Month", "Revenue", "Expenses", "Profit"],
-      ["January", "5000", "3000", "2000"],
-      ["February", "5500", "3200", "2300"]
-    ]
+    "account": {{ options.google_account | json }},
+    "operation": "append_rows",
+    "spreadsheet_id": {{ options.spreadsheet_id | json }},
+    "rows": {{ order_rows | json }}
   }
 {% endaction %}
 ```
 
-### Create a Spreadsheet with Multiple Sheets
+Response:
 
-```liquid
-{% action "google_sheets" %}
-  {
-    "account": "user@example.com",
-    "operation": "create_spreadsheet",
-    "title": "Sales Report",
-    "sheets": [
-      {
-        "name": "Orders",
-        "rows": [["Order ID", "Total"]]
-      },
-      {
-        "name": "Refunds",
-        "rows": [["Refund ID", "Amount"]]
-      }
-    ]
-  }
-{% endaction %}
+```json
+{
+  "spreadsheet_id": "1234567890abcdef",
+  "updated_range": "Orders!A1:C3",
+  "updated_rows": 3,
+  "updated_columns": 3,
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
+}
 ```
 
-### Add a Sheet to an Existing Spreadsheet
+## update\_rows
 
-```liquid
-{% action "google_sheets" %}
-  {
-    "account": "user@example.com",
-    "operation": "add_sheet",
-    "spreadsheet_id": "1234567890abcdef",
-    "sheet_name": "Q3",
-    "rows": [["Date", "Revenue"]]
-  }
-{% endaction %}
-```
+Writes rows at a specific range, overwriting whatever is there.
 
-### Update Rows at a Specific Range
+| Option                | Required               | Notes                                                                 |
+| --------------------- | ---------------------- | ---------------------------------------------------------------------- |
+| `rows`                | yes                    | Array of arrays                                                         |
+| `sheet_range`         | one of these two       | e.g. `"Orders!A5:C5"`                                                   |
+| `sheet_name`          | one of these two       | Alone, writes starting at the sheet's A1                                |
+| `value_input_option`  | no                     | See [Writing values](#writing-values)                                   |
 
 ```liquid
 {% action "google_sheets" %}
@@ -289,79 +194,65 @@ archives/exports/sheets   # Three levels deep
     "operation": "update_rows",
     "spreadsheet_id": "1234567890abcdef",
     "sheet_range": "Orders!A5:C5",
-    "rows": [
-      ["1001", "John Doe", "129.99"]
-    ]
+    "rows": [["1001", "John Doe", "129.99"]]
   }
 {% endaction %}
 ```
 
-### Parse Dates and Formulas with user\_entered
+Response:
+
+```json
+{
+  "spreadsheet_id": "1234567890abcdef",
+  "updated_range": "Orders!A5:C5",
+  "updated_rows": 1,
+  "updated_columns": 3,
+  "updated_cells": 3,
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
+}
+```
+
+## clear\_values
+
+Clears the values in a range; formatting is left intact.
+
+| Option         | Required          | Notes                                |
+| -------------- | ----------------- | ------------------------------------- |
+| `sheet_range`  | one of these two  | The range to clear                    |
+| `sheet_name`   | one of these two  | Alone, clears the entire sheet        |
 
 ```liquid
 {% action "google_sheets" %}
   {
     "account": "user@example.com",
-    "operation": "append_rows",
+    "operation": "clear_values",
     "spreadsheet_id": "1234567890abcdef",
-    "sheet_name": "Totals",
-    "value_input_option": "user_entered",
-    "rows": [
-      ["2026-06-09", 49.99, "=SUM(B:B)"]
-    ]
+    "sheet_range": "Orders!A2:C100"
   }
 {% endaction %}
 ```
 
-### Delete Rows
+Response:
 
-```liquid
-{% action "google_sheets" %}
-  {
-    "account": "user@example.com",
-    "operation": "delete_rows",
-    "spreadsheet_id": "1234567890abcdef",
-    "sheet_name": "Orders",
-    "start_row": 5,
-    "end_row": 7
-  }
-{% endaction %}
+```json
+{
+  "spreadsheet_id": "1234567890abcdef",
+  "cleared_range": "Orders!A2:C100",
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
+}
 ```
 
-### Export Google Sheet
+## get\_values
 
-```liquid
-{% action "google_sheets" %}
-  {
-    "account": "user@example.com",
-    "operation": "export_spreadsheet",
-    "spreadsheet_id": "1234567890abcdef",
-    "file_type": "pdf"
-  }
-{% endaction %}
-```
+Reads values from a range into the action's result. Results are capped at 20MB; narrow the range for very large sheets.
 
-### Append Rows with Transient Error Retries
+| Option                 | Required | Notes                                                                                                 |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| `sheet_range`          | no       | Defaults to the entire first sheet when neither this nor `sheet_name` is given                           |
+| `sheet_name`           | no       | Alone, reads the entire named sheet                                                                      |
+| `value_render_option`  | no       | `"formatted_value"` (default), `"unformatted_value"` (raw numbers), or `"formula"` (cell formulas)       |
 
-```liquid
-{% action "google_sheets" %}
-  {
-    "account": "user@example.com",
-    "operation": "append_rows",
-    "spreadsheet_id": "1234567890abcdef",
-    "sheet_name": "Sheet1",
-    "retry_on_transient_errors": true,
-    "rows": [
-      ["Order ID", "Customer Email", "Total"],
-      [{{ order.id | json }}, {{ order.email | json }}, {{ order.total_price | json }}]
-    ]
-  }
-{% endaction %}
-```
-
-### Read Data from a Google Sheet
-
-Use `get_values` together with a `mechanic/actions/perform` subscription to read data back into a task — for example, as the first pass of a find-then-update workflow.
+Pair it with a `mechanic/actions/perform` subscription to use the values in a task — for example, finding which row holds a particular order before updating or deleting it:
 
 {% code title="Task subscriptions" %}
 
@@ -392,169 +283,178 @@ mechanic/actions/perform
 
 {% endcode %}
 
-### Dynamic Data Example
-
-```liquid
-{% assign order_rows = array %}
-
-{% for order in shop.orders %}
-  {% assign order_row = array %}
-  {% assign order_row[0] = order.name %}
-  {% assign order_row[1] = order.customer.name %}
-  {% assign order_row[2] = order.total_price %}
-  {% assign order_rows[order_rows.size] = order_row %}
-{% endfor %}
-
-{% action "google_sheets" %}
-  {
-    "account": {{ options.google_account | json }},
-    "operation": "append_rows",
-    "spreadsheet_id": {{ options.spreadsheet_id | json }},
-    "rows": {{ order_rows | json }}
-  }
-{% endaction %}
-```
-
-## Action Responses
-
-The action returns different responses based on the operation performed:
-
-### append\_rows Response
-
-```typescript
-{
-  "spreadsheet_id": string,
-  "updated_range": string,
-  "updated_rows": number,
-  "updated_columns": number,
-  "spreadsheet_url": string
-}
-```
-
-### create\_spreadsheet Response
-
-```typescript
-{
-  "spreadsheet_id": string,
-  "spreadsheet_url": string,
-  "title": string,
-  "folder_path": string | null,
-  "sheets": [{ "name": string, "sheet_id": number }] // present when created with "sheets"
-}
-```
-
-Example:
+Response:
 
 ```json
 {
   "spreadsheet_id": "1234567890abcdef",
-  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef",
-  "title": "Sales Report",
-  "folder_path": "reports/2026",
-  "sheets": [
-    { "name": "Orders", "sheet_id": 0 },
-    { "name": "Refunds", "sheet_id": 1234 }
-  ]
+  "range": "Orders!A1:C100",
+  "values": [["Order ID", "Customer", "Total"], ["1001", "John Doe", "99.99"]],
+  "row_count": 2,
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
 }
 ```
 
-### add\_sheet Response
+## delete\_rows
 
-```typescript
+Deletes a span of rows entirely — rows below shift up. Row numbers are 1-based and inclusive, matching what you see in the Sheets UI.
+
+{% hint style="warning" %}
+This operation is destructive, and is never retried automatically — see [Retries](#retries). `sheet_name` is always required, so a reordering of tabs can never redirect a deletion to the wrong sheet.
+{% endhint %}
+
+| Option       | Required | Notes                                          |
+| ------------ | -------- | ----------------------------------------------- |
+| `sheet_name` | yes      |                                                 |
+| `start_row`  | yes      | 1-based                                         |
+| `end_row`    | no       | Defaults to `start_row` (deletes a single row)  |
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "delete_rows",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Orders",
+    "start_row": 5,
+    "end_row": 7
+  }
+{% endaction %}
+```
+
+Response:
+
+```json
 {
-  "spreadsheet_id": string,
-  "sheet_id": number,
-  "sheet_name": string,
-  "spreadsheet_url": string,
-  "updated_rows": number,    // present when rows were written
-  "updated_columns": number  // present when rows were written
+  "spreadsheet_id": "1234567890abcdef",
+  "sheet_name": "Orders",
+  "start_row": 5,
+  "end_row": 7,
+  "deleted_rows": 3,
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
 }
 ```
 
-### update\_rows Response
+## add\_sheet
 
-```typescript
+Adds a new sheet (tab) to an existing spreadsheet, optionally populated with initial rows.
+
+| Option                | Required | Notes                                  |
+| --------------------- | -------- | --------------------------------------- |
+| `sheet_name`          | yes      | Must not already exist                  |
+| `rows`                | no       | Initial data for the new sheet          |
+| `value_input_option`  | no       | See [Writing values](#writing-values)   |
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "add_sheet",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Q3",
+    "rows": [["Date", "Revenue"]]
+  }
+{% endaction %}
+```
+
+Response:
+
+```json
 {
-  "spreadsheet_id": string,
-  "updated_range": string,
-  "updated_rows": number,
-  "updated_columns": number,
-  "updated_cells": number,
-  "spreadsheet_url": string
+  "spreadsheet_id": "1234567890abcdef",
+  "sheet_id": 5678,
+  "sheet_name": "Q3",
+  "updated_rows": 1,
+  "updated_columns": 2,
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
 }
 ```
 
-### clear\_values Response
+(`updated_rows`/`updated_columns` are present when `rows` were written.)
 
-```typescript
+## rename\_sheet
+
+Renames a sheet (tab), located by its current name.
+
+| Option            | Required | Notes                       |
+| ----------------- | -------- | ---------------------------- |
+| `sheet_name`      | yes      | The current name             |
+| `new_sheet_name`  | yes      | Must not already exist       |
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "rename_sheet",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Q3",
+    "new_sheet_name": "Q3 Archive"
+  }
+{% endaction %}
+```
+
+Response:
+
+```json
 {
-  "spreadsheet_id": string,
-  "cleared_range": string,
-  "spreadsheet_url": string
+  "spreadsheet_id": "1234567890abcdef",
+  "sheet_id": 5678,
+  "previous_sheet_name": "Q3",
+  "sheet_name": "Q3 Archive",
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
 }
 ```
 
-### get\_values Response
+## delete\_sheet
 
-```typescript
+Deletes a sheet (tab) by name. A spreadsheet's last remaining sheet cannot be deleted. Like `delete_rows`, this is never retried automatically — see [Retries](#retries).
+
+| Option       | Required |
+| ------------ | -------- |
+| `sheet_name` | yes      |
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "delete_sheet",
+    "spreadsheet_id": "1234567890abcdef",
+    "sheet_name": "Q3 Archive"
+  }
+{% endaction %}
+```
+
+Response:
+
+```json
 {
-  "spreadsheet_id": string,
-  "range": string,
-  "values": string[][],
-  "row_count": number,
-  "spreadsheet_url": string
+  "spreadsheet_id": "1234567890abcdef",
+  "sheet_id": 5678,
+  "sheet_name": "Q3 Archive",
+  "spreadsheet_url": "https://docs.google.com/spreadsheets/d/1234567890abcdef"
 }
 ```
 
-### delete\_rows Response
+## export\_spreadsheet
 
-```typescript
-{
-  "spreadsheet_id": string,
-  "sheet_name": string,
-  "start_row": number,
-  "end_row": number,
-  "deleted_rows": number,
-  "spreadsheet_url": string
-}
+Exports a spreadsheet. The exported file arrives base64-encoded in the action result.
+
+| Option      | Required | Notes                                                          |
+| ----------- | -------- | --------------------------------------------------------------- |
+| `file_type` | no       | `"xlsx"` (default), `"csv"`, `"pdf"`, `"html"`, `"ods"`, `"tsv"` |
+
+```liquid
+{% action "google_sheets" %}
+  {
+    "account": "user@example.com",
+    "operation": "export_spreadsheet",
+    "spreadsheet_id": "1234567890abcdef",
+    "file_type": "pdf"
+  }
+{% endaction %}
 ```
 
-### rename\_sheet Response
-
-```typescript
-{
-  "spreadsheet_id": string,
-  "sheet_id": number,
-  "previous_sheet_name": string,
-  "sheet_name": string,
-  "spreadsheet_url": string
-}
-```
-
-### delete\_sheet Response
-
-```typescript
-{
-  "spreadsheet_id": string,
-  "sheet_id": number,
-  "sheet_name": string,
-  "spreadsheet_url": string
-}
-```
-
-### export\_spreadsheet Response
-
-```typescript
-{
-  "spreadsheet_id": string,
-  "name": string,
-  "size": number,
-  "file_type": string,
-  "data_base64": string
-}
-```
-
-Example:
+Response:
 
 ```json
 {
@@ -565,3 +465,22 @@ Example:
   "data_base64": "base64encodeddata..."
 }
 ```
+
+***
+
+## Authentication
+
+This action requires connecting a Google account with the appropriate permissions. To connect an account:
+
+1. Go to **Settings → Authentication**
+2. Select **Google** in the provider list
+3. Follow the Google account connection flow
+
+## Folders
+
+When creating spreadsheets, use `folder_path` to organize your files:
+
+* Use forward slashes to separate folder names (e.g., `"reports/2026/monthly"`)
+* Folders will be created if they don't exist
+* Mechanic can only access folders created by this integration
+* Invalid characters not allowed: `< > : " / \ | ? *`


### PR DESCRIPTION
## Summary

Follow-up to #56, addressing feedback that the published page is hard to read: each operation's story was scattered across three distant places (the giant combined options table, its operation section, and its example + response in mega-sections at the bottom), and the page had grown to ~3x the size of any other action doc.

New structure:

- **Linked operations index** right after the intro — one line per operation, anchor-linked to its section (same pattern as the topic index on `platform/events/topics.md`)
- **Four short shared-convention sections**: targeting sheets/ranges, writing values (with the `user_entered` formula warning), retry semantics (consolidated in one place instead of sprinkled), and auth/folders
- **One self-contained section per operation**: its own compact options table (required/optional at a glance), example, and response shape together — no more cross-referencing three parts of the page

No technical content was removed — the locale handling notes, 20MB `get_values` cap, retry semantics including the rate-limit exception, and the destructive-operation warnings all carry over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)